### PR TITLE
Fix keyboard focus trapping in math result widget

### DIFF
--- a/crates/nwg-drawer/src/ui/math.rs
+++ b/crates/nwg-drawer/src/ui/math.rs
@@ -48,13 +48,17 @@ pub fn build_math_result(phrase: &str) -> Option<gtk4::Box> {
     vbox.set_halign(gtk4::Align::Center);
     vbox.set_margin_top(super::constants::STATUS_AREA_VERTICAL_MARGIN);
     vbox.set_margin_bottom(super::constants::STATUS_AREA_VERTICAL_MARGIN);
+    // Don't trap focus in the math result — allow Tab to move through to search results below
+    vbox.set_focusable(false);
 
     let row = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
     row.set_halign(gtk4::Align::Center);
+    row.set_focusable(false);
 
     let label = gtk4::Label::new(Some(&label_text));
     label.add_css_class("math-result");
     label.set_halign(gtk4::Align::End);
+    label.set_focusable(false);
     row.append(&label);
 
     // Copy button — copies the result to clipboard via wl-copy.


### PR DESCRIPTION
## Summary
- Make math result vbox, row, and label non-focusable so Tab/arrow keys pass through to file search results below
- Only the Copy button retains focus participation

Reported by nwg-piotr in #1 — keyboard-driven focus was getting trapped on the math result and couldn't reach filenames below.

## Test plan
- [x] `cargo test --workspace` — 215 tests pass
- [x] `cargo clippy --all-targets` — zero warnings
- [x] Manual: type expression with file results, Tab moves past math to files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation in the math result widget by preventing unnecessary focus on container elements while preserving focus on interactive controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->