### PR TITLE
Use nwg-* layer-shell namespaces matching Go original

### DIFF
--- a/crates/nwg-dock/src/ui/window.rs
+++ b/crates/nwg-dock/src/ui/window.rs
@@ -4,7 +4,7 @@ use gtk4_layer_shell::LayerShell;
 /// Configures the main dock window with layer-shell properties.
 pub fn setup_dock_window(win: &gtk4::ApplicationWindow, config: &DockConfig) {
     win.init_layer_shell();
-    win.set_namespace(Some("mac-dock"));
+    win.set_namespace(Some("nwg-dock-hyprland"));
 
     // Position anchoring
     match config.position {

--- a/crates/nwg-drawer/src/ui/window.rs
+++ b/crates/nwg-drawer/src/ui/window.rs
@@ -8,7 +8,7 @@ pub fn setup_drawer_window(
     monitor: Option<&gtk4::gdk::Monitor>,
 ) {
     win.init_layer_shell();
-    win.set_namespace(Some("mac-drawer"));
+    win.set_namespace(Some("nwg-drawer"));
 
     if let Some(mon) = monitor {
         win.set_monitor(Some(mon));

--- a/crates/nwg-notifications/src/ui/dnd_menu.rs
+++ b/crates/nwg-notifications/src/ui/dnd_menu.rs
@@ -165,7 +165,7 @@ fn setup_backdrop_window(win: &gtk4::ApplicationWindow) {
 
 fn setup_menu_window(win: &gtk4::ApplicationWindow) {
     win.init_layer_shell();
-    win.set_namespace(Some("mac-notification-dnd-menu"));
+    win.set_namespace(Some("nwg-notification-dnd-menu"));
     win.set_layer(gtk4_layer_shell::Layer::Overlay);
     win.set_exclusive_zone(-1);
     win.set_keyboard_mode(gtk4_layer_shell::KeyboardMode::OnDemand);

--- a/crates/nwg-notifications/src/ui/panel.rs
+++ b/crates/nwg-notifications/src/ui/panel.rs
@@ -166,7 +166,7 @@ fn hide_panel(
 
 fn setup_panel_window(win: &gtk4::ApplicationWindow) {
     win.init_layer_shell();
-    win.set_namespace(Some("mac-notification-panel"));
+    win.set_namespace(Some("nwg-notification-panel"));
     win.set_layer(gtk4_layer_shell::Layer::Overlay);
     win.set_exclusive_zone(-1);
     win.set_keyboard_mode(gtk4_layer_shell::KeyboardMode::OnDemand);

--- a/crates/nwg-notifications/src/ui/window.rs
+++ b/crates/nwg-notifications/src/ui/window.rs
@@ -4,7 +4,7 @@ use gtk4_layer_shell::LayerShell;
 /// Configures a popup window with layer-shell properties.
 pub fn setup_popup_window(win: &gtk4::ApplicationWindow, position: PopupPosition, top_offset: i32) {
     win.init_layer_shell();
-    win.set_namespace(Some("mac-notification-popup"));
+    win.set_namespace(Some("nwg-notification-popup"));
     win.set_layer(gtk4_layer_shell::Layer::Overlay);
     win.set_exclusive_zone(-1);
 


### PR DESCRIPTION
## Summary
- Change layer-shell namespaces from `mac-*` to `nwg-*` so existing Hyprland layer rules (blur, opacity, animation) work without reconfiguration
- `nwg-dock-hyprland`, `nwg-drawer`, `nwg-notification-popup`, `nwg-notification-panel`, `nwg-notification-dnd-menu`
- `nwg-dock-hotspot` was already correct

Requested by nwg-piotr in #1 — couldn't set blur on the drawer layer because namespace didn't match.

## Test plan
- [x] `hyprctl layers` confirms `nwg-drawer` namespace
- [x] `cargo clippy --all-targets` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal window identifiers for dock, drawer, and notification system components to align with consistent naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->