### PR TITLE
Add -v short flag for --version

### DIFF
--- a/crates/nwg-dock-common/src/config/flags.rs
+++ b/crates/nwg-dock-common/src/config/flags.rs
@@ -9,6 +9,10 @@ pub fn normalize_legacy_flags(
     legacy_flags: &'static [&'static str],
 ) -> Vec<String> {
     args.map(|arg| {
+        // Map -v to --version (Go compatibility for nwg-shell config utility)
+        if arg == "-v" {
+            return "--version".to_string();
+        }
         // Convert -flag or -flag=value to --flag or --flag=value
         if let Some(name) = arg.strip_prefix('-')
             && !name.starts_with('-')
@@ -62,8 +66,15 @@ mod tests {
 
     #[test]
     fn preserves_single_char_flags() {
-        let args = vec!["test".into(), "-d".into(), "-v".into()];
+        let args = vec!["test".into(), "-d".into()];
         let result = normalize_legacy_flags(args.into_iter(), TEST_FLAGS);
-        assert_eq!(result, vec!["test", "-d", "-v"]);
+        assert_eq!(result, vec!["test", "-d"]);
+    }
+
+    #[test]
+    fn converts_v_to_version() {
+        let args = vec!["test".into(), "-v".into()];
+        let result = normalize_legacy_flags(args.into_iter(), TEST_FLAGS);
+        assert_eq!(result, vec!["test", "--version"]);
     }
 }

--- a/crates/nwg-dock-common/src/config/flags.rs
+++ b/crates/nwg-dock-common/src/config/flags.rs
@@ -8,10 +8,22 @@ pub fn normalize_legacy_flags(
     args: impl Iterator<Item = String>,
     legacy_flags: &'static [&'static str],
 ) -> Vec<String> {
-    args.map(|arg| {
+    let mut result = Vec::new();
+    let mut passthrough = false;
+    for arg in args {
+        if passthrough {
+            result.push(arg);
+            continue;
+        }
+        if arg == "--" {
+            passthrough = true;
+            result.push(arg);
+            continue;
+        }
         // Map -v to --version (Go compatibility for nwg-shell config utility)
         if arg == "-v" {
-            return "--version".to_string();
+            result.push("--version".to_string());
+            continue;
         }
         // Convert -flag or -flag=value to --flag or --flag=value
         if let Some(name) = arg.strip_prefix('-')
@@ -19,15 +31,17 @@ pub fn normalize_legacy_flags(
         {
             if let Some((flag, value)) = name.split_once('=') {
                 if legacy_flags.contains(&flag) {
-                    return format!("--{}={}", flag, value);
+                    result.push(format!("--{}={}", flag, value));
+                    continue;
                 }
             } else if legacy_flags.contains(&name) {
-                return format!("--{}", name);
+                result.push(format!("--{}", name));
+                continue;
             }
         }
-        arg
-    })
-    .collect()
+        result.push(arg);
+    }
+    result
 }
 
 #[cfg(test)]
@@ -76,5 +90,12 @@ mod tests {
         let args = vec!["test".into(), "-v".into()];
         let result = normalize_legacy_flags(args.into_iter(), TEST_FLAGS);
         assert_eq!(result, vec!["test", "--version"]);
+    }
+
+    #[test]
+    fn stops_normalizing_after_double_dash() {
+        let args = vec!["test".into(), "--".into(), "-v".into(), "-hd".into()];
+        let result = normalize_legacy_flags(args.into_iter(), TEST_FLAGS);
+        assert_eq!(result, vec!["test", "--", "-v", "-hd"]);
     }
 }


### PR DESCRIPTION
## Summary
- Map `-v` to `--version` in the shared legacy flag normalizer so nwg-shell's config utility (`System info` tab) can query version info
- Applied in `nwg-dock-common` so all three binaries (dock, drawer, notifications) support it
- `-V` (clap default) and `--version` continue to work

## Test plan
- [x] 229 unit tests pass (1 new)
- [x] Clippy zero warnings
- [x] `nwg-drawer -v` → `nwg-drawer 0.1.0`
- [x] `nwg-dock-hyprland -v` → `nwg-dock-hyprland 0.1.0`
- [x] `--version` still works on both

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of the legacy `-v` argument so it is now treated as `--version`.
  * Stopped normalizing flags after a standalone `--`, preserving subsequent arguments exactly as provided.

* **Tests**
  * Added/updated unit tests to verify `-v` conversion and that normalization ceases after `--`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->