### PR TITLE
Drawer runs on any compositor via NullCompositor fallback (#56)

### DIFF
--- a/crates/nwg-dock-common/src/compositor/mod.rs
+++ b/crates/nwg-dock-common/src/compositor/mod.rs
@@ -1,9 +1,11 @@
 mod hyprland;
+mod null;
 mod sway;
 pub mod traits;
 pub mod types;
 
 use crate::error::{DockError, Result};
+pub use null::NullCompositor;
 pub use traits::{Compositor, WmEventStream};
 pub use types::{WmClient, WmEvent, WmMonitor, WmWorkspace};
 
@@ -57,7 +59,7 @@ pub fn create(kind: CompositorKind) -> Result<Box<dyn Compositor>> {
 
 /// Detects and creates the compositor backend, exiting the process on failure.
 ///
-/// Shared by all three binaries (dock, drawer, notifications) to avoid duplication.
+/// Used by dock and notifications which require full compositor IPC.
 pub fn init_or_exit(wm_override: Option<WmOverride>) -> Box<dyn Compositor> {
     let kind = match detect(wm_override) {
         Ok(k) => k,
@@ -71,6 +73,25 @@ pub fn init_or_exit(wm_override: Option<WmOverride>) -> Box<dyn Compositor> {
         Err(e) => {
             log::error!("{}", e);
             std::process::exit(1);
+        }
+    }
+}
+
+/// Detects and creates the compositor backend, falling back to NullCompositor
+/// on failure instead of exiting. Used by nwg-drawer so it can run on any
+/// compositor (Niri, river, Openbox, etc.) with graceful feature degradation.
+pub fn init_or_null(wm_override: Option<WmOverride>) -> Box<dyn Compositor> {
+    match detect(wm_override) {
+        Ok(kind) => match create(kind) {
+            Ok(c) => c,
+            Err(e) => {
+                log::warn!("Compositor backend failed: {} — using fallback", e);
+                Box::new(NullCompositor)
+            }
+        },
+        Err(_) => {
+            log::info!("No supported compositor detected — running with limited features");
+            Box::new(NullCompositor)
         }
     }
 }

--- a/crates/nwg-dock-common/src/compositor/null.rs
+++ b/crates/nwg-dock-common/src/compositor/null.rs
@@ -1,5 +1,5 @@
 use super::traits::{Compositor, WmEventStream};
-use super::types::{WmClient, WmEvent, WmMonitor};
+use super::types::{WmClient, WmMonitor};
 use crate::error::{DockError, Result};
 
 /// Fallback compositor backend for environments without Hyprland or Sway IPC.
@@ -56,28 +56,24 @@ impl Compositor for NullCompositor {
 
     /// Launches the command directly via process spawn instead of compositor IPC.
     /// The drawer's launch pipeline handles quoting and field-code stripping upstream.
+    /// Rejects empty commands so the caller can distinguish success from a no-op.
     fn exec(&self, cmd: &str) -> Result<()> {
+        if cmd.trim().is_empty() {
+            return Err(DockError::NoCompositorDetected);
+        }
         crate::launch::launch_command(cmd);
         Ok(())
     }
 
+    /// NullCompositor has no compositor IPC, so there's no event stream to
+    /// subscribe to. Fail fast rather than returning a stream that blocks
+    /// forever — callers can then avoid spawning a worker thread at all.
     fn event_stream(&self) -> Result<Box<dyn WmEventStream>> {
-        Ok(Box::new(NullEventStream))
+        Err(DockError::NoCompositorDetected)
     }
 
     fn supports_cursor_position(&self) -> bool {
         false
-    }
-}
-
-/// Event stream that never emits events — used by NullCompositor.
-struct NullEventStream;
-
-impl WmEventStream for NullEventStream {
-    fn next_event(&mut self) -> std::result::Result<WmEvent, std::io::Error> {
-        // Block forever — no events will ever arrive
-        std::thread::park();
-        Err(std::io::Error::other("null event stream unparked"))
     }
 }
 
@@ -119,9 +115,10 @@ mod tests {
     }
 
     #[test]
-    fn event_stream_creates_successfully() {
-        // The stream itself will block forever on next_event — just verify creation.
-        assert!(NullCompositor.event_stream().is_ok());
+    fn event_stream_returns_error() {
+        // NullCompositor fails fast instead of returning a stream that
+        // blocks forever — prevents stranding worker threads.
+        assert!(NullCompositor.event_stream().is_err());
     }
 
     #[test]
@@ -133,8 +130,10 @@ mod tests {
     }
 
     #[test]
-    fn exec_empty_command_returns_ok() {
-        // launch_command logs an error but doesn't panic on empty input
-        assert!(NullCompositor.exec("").is_ok());
+    fn exec_empty_command_returns_error() {
+        // Reject empty/whitespace input so callers can distinguish
+        // "launched" from "nothing happened"
+        assert!(NullCompositor.exec("").is_err());
+        assert!(NullCompositor.exec("   ").is_err());
     }
 }

--- a/crates/nwg-dock-common/src/compositor/null.rs
+++ b/crates/nwg-dock-common/src/compositor/null.rs
@@ -1,0 +1,140 @@
+use super::traits::{Compositor, WmEventStream};
+use super::types::{WmClient, WmEvent, WmMonitor};
+use crate::error::{DockError, Result};
+
+/// Fallback compositor backend for environments without Hyprland or Sway IPC.
+///
+/// Used by `nwg-drawer` so it can run on any compositor (Niri, river, Openbox, etc.).
+/// Most methods return errors — the drawer already handles those gracefully.
+/// The one exception is the launch path, which falls back to direct process spawn.
+pub struct NullCompositor;
+
+impl Compositor for NullCompositor {
+    fn list_clients(&self) -> Result<Vec<WmClient>> {
+        Err(DockError::NoCompositorDetected)
+    }
+
+    fn list_monitors(&self) -> Result<Vec<WmMonitor>> {
+        Err(DockError::NoCompositorDetected)
+    }
+
+    fn get_active_window(&self) -> Result<WmClient> {
+        Err(DockError::NoCompositorDetected)
+    }
+
+    fn get_cursor_position(&self) -> Option<(i32, i32)> {
+        None
+    }
+
+    fn focus_window(&self, _id: &str) -> Result<()> {
+        Err(DockError::NoCompositorDetected)
+    }
+
+    fn close_window(&self, _id: &str) -> Result<()> {
+        Err(DockError::NoCompositorDetected)
+    }
+
+    fn toggle_floating(&self, _id: &str) -> Result<()> {
+        Err(DockError::NoCompositorDetected)
+    }
+
+    fn toggle_fullscreen(&self, _id: &str) -> Result<()> {
+        Err(DockError::NoCompositorDetected)
+    }
+
+    fn move_to_workspace(&self, _id: &str, _workspace: i32) -> Result<()> {
+        Err(DockError::NoCompositorDetected)
+    }
+
+    fn toggle_special_workspace(&self, _name: &str) -> Result<()> {
+        Err(DockError::NoCompositorDetected)
+    }
+
+    fn raise_active(&self) -> Result<()> {
+        Err(DockError::NoCompositorDetected)
+    }
+
+    /// Launches the command directly via process spawn instead of compositor IPC.
+    /// The drawer's launch pipeline handles quoting and field-code stripping upstream.
+    fn exec(&self, cmd: &str) -> Result<()> {
+        crate::launch::launch_command(cmd);
+        Ok(())
+    }
+
+    fn event_stream(&self) -> Result<Box<dyn WmEventStream>> {
+        Ok(Box::new(NullEventStream))
+    }
+
+    fn supports_cursor_position(&self) -> bool {
+        false
+    }
+}
+
+/// Event stream that never emits events — used by NullCompositor.
+struct NullEventStream;
+
+impl WmEventStream for NullEventStream {
+    fn next_event(&mut self) -> std::result::Result<WmEvent, std::io::Error> {
+        // Block forever — no events will ever arrive
+        std::thread::park();
+        Err(std::io::Error::other("null event stream unparked"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_clients_returns_error() {
+        assert!(NullCompositor.list_clients().is_err());
+    }
+
+    #[test]
+    fn list_monitors_returns_error() {
+        assert!(NullCompositor.list_monitors().is_err());
+    }
+
+    #[test]
+    fn get_active_window_returns_error() {
+        assert!(NullCompositor.get_active_window().is_err());
+    }
+
+    #[test]
+    fn cursor_position_unsupported() {
+        assert!(!NullCompositor.supports_cursor_position());
+        assert_eq!(NullCompositor.get_cursor_position(), None);
+    }
+
+    #[test]
+    fn window_operations_return_errors() {
+        let c = NullCompositor;
+        assert!(c.focus_window("x").is_err());
+        assert!(c.close_window("x").is_err());
+        assert!(c.toggle_floating("x").is_err());
+        assert!(c.toggle_fullscreen("x").is_err());
+        assert!(c.move_to_workspace("x", 1).is_err());
+        assert!(c.toggle_special_workspace("x").is_err());
+        assert!(c.raise_active().is_err());
+    }
+
+    #[test]
+    fn event_stream_creates_successfully() {
+        // The stream itself will block forever on next_event — just verify creation.
+        assert!(NullCompositor.event_stream().is_ok());
+    }
+
+    #[test]
+    fn exec_launches_trivial_command() {
+        // /bin/true exits immediately with status 0. This verifies the exec
+        // path actually spawns a subprocess rather than erroring out.
+        // Direct spawn path — no shell, no side effects.
+        assert!(NullCompositor.exec("/bin/true").is_ok());
+    }
+
+    #[test]
+    fn exec_empty_command_returns_ok() {
+        // launch_command logs an error but doesn't panic on empty input
+        assert!(NullCompositor.exec("").is_ok());
+    }
+}

--- a/crates/nwg-dock-common/src/compositor/null.rs
+++ b/crates/nwg-dock-common/src/compositor/null.rs
@@ -112,6 +112,10 @@ mod tests {
         assert_eq!(NullCompositor.get_cursor_position(), None);
     }
 
+    /// Arbitrary workspace id for testing — the NullCompositor rejects
+    /// any value, so the specific number is irrelevant.
+    const TEST_WORKSPACE: i32 = 1;
+
     #[test]
     fn window_operations_return_no_compositor_error() {
         let c = NullCompositor;
@@ -119,7 +123,7 @@ mod tests {
         assert_no_compositor(c.close_window("x"));
         assert_no_compositor(c.toggle_floating("x"));
         assert_no_compositor(c.toggle_fullscreen("x"));
-        assert_no_compositor(c.move_to_workspace("x", 1));
+        assert_no_compositor(c.move_to_workspace("x", TEST_WORKSPACE));
         assert_no_compositor(c.toggle_special_workspace("x"));
         assert_no_compositor(c.raise_active());
     }

--- a/crates/nwg-dock-common/src/compositor/null.rs
+++ b/crates/nwg-dock-common/src/compositor/null.rs
@@ -81,19 +81,29 @@ impl Compositor for NullCompositor {
 mod tests {
     use super::*;
 
-    #[test]
-    fn list_clients_returns_error() {
-        assert!(NullCompositor.list_clients().is_err());
+    /// Helper: asserts the result is specifically Err(NoCompositorDetected),
+    /// not just any error — catches regressions to unrelated error paths.
+    fn assert_no_compositor<T: std::fmt::Debug>(result: Result<T>) {
+        assert!(
+            matches!(result, Err(DockError::NoCompositorDetected)),
+            "expected NoCompositorDetected, got {:?}",
+            result
+        );
     }
 
     #[test]
-    fn list_monitors_returns_error() {
-        assert!(NullCompositor.list_monitors().is_err());
+    fn list_clients_returns_no_compositor_error() {
+        assert_no_compositor(NullCompositor.list_clients());
     }
 
     #[test]
-    fn get_active_window_returns_error() {
-        assert!(NullCompositor.get_active_window().is_err());
+    fn list_monitors_returns_no_compositor_error() {
+        assert_no_compositor(NullCompositor.list_monitors());
+    }
+
+    #[test]
+    fn get_active_window_returns_no_compositor_error() {
+        assert_no_compositor(NullCompositor.get_active_window());
     }
 
     #[test]
@@ -103,22 +113,25 @@ mod tests {
     }
 
     #[test]
-    fn window_operations_return_errors() {
+    fn window_operations_return_no_compositor_error() {
         let c = NullCompositor;
-        assert!(c.focus_window("x").is_err());
-        assert!(c.close_window("x").is_err());
-        assert!(c.toggle_floating("x").is_err());
-        assert!(c.toggle_fullscreen("x").is_err());
-        assert!(c.move_to_workspace("x", 1).is_err());
-        assert!(c.toggle_special_workspace("x").is_err());
-        assert!(c.raise_active().is_err());
+        assert_no_compositor(c.focus_window("x"));
+        assert_no_compositor(c.close_window("x"));
+        assert_no_compositor(c.toggle_floating("x"));
+        assert_no_compositor(c.toggle_fullscreen("x"));
+        assert_no_compositor(c.move_to_workspace("x", 1));
+        assert_no_compositor(c.toggle_special_workspace("x"));
+        assert_no_compositor(c.raise_active());
     }
 
     #[test]
-    fn event_stream_returns_error() {
+    fn event_stream_returns_no_compositor_error() {
         // NullCompositor fails fast instead of returning a stream that
         // blocks forever — prevents stranding worker threads.
-        assert!(NullCompositor.event_stream().is_err());
+        assert!(matches!(
+            NullCompositor.event_stream(),
+            Err(DockError::NoCompositorDetected)
+        ));
     }
 
     #[test]
@@ -130,10 +143,10 @@ mod tests {
     }
 
     #[test]
-    fn exec_empty_command_returns_error() {
+    fn exec_empty_command_returns_no_compositor_error() {
         // Reject empty/whitespace input so callers can distinguish
         // "launched" from "nothing happened"
-        assert!(NullCompositor.exec("").is_err());
-        assert!(NullCompositor.exec("   ").is_err());
+        assert_no_compositor(NullCompositor.exec(""));
+        assert_no_compositor(NullCompositor.exec("   "));
     }
 }

--- a/crates/nwg-dock-common/src/config/css.rs
+++ b/crates/nwg-dock-common/src/config/css.rs
@@ -25,10 +25,7 @@ pub fn load_css(css_path: &Path) -> gtk4::CssProvider {
         provider.load_from_path(css_path);
         log::info!("Loaded CSS from {}", css_path.display());
     } else {
-        log::info!(
-            "{} not found — watching for creation",
-            css_path.display()
-        );
+        log::info!("{} not found — watching for creation", css_path.display());
     }
 
     apply_provider(&provider, CSS_PRIORITY_USER);
@@ -60,35 +57,45 @@ pub fn load_css_override(css: &str) -> gtk4::CssProvider {
 /// The watcher thread runs until the provider is dropped.
 pub fn watch_css(css_path: &Path, provider: &gtk4::CssProvider) {
     let path = css_path.to_path_buf();
-    let provider = provider.clone();
-
-    // Watch the parent directory (inotify can't watch a file that might be
-    // replaced atomically via rename, which is how most editors save).
-    let watch_dir = match path.parent() {
-        Some(dir) => dir.to_path_buf(),
-        None => {
-            log::debug!("CSS watch skipped: no parent directory for {}", path.display());
-            return;
-        }
-    };
-    let file_name = match path.file_name() {
-        Some(name) => name.to_os_string(),
-        None => {
-            log::debug!("CSS watch skipped: no filename for {}", path.display());
-            return;
-        }
+    let Some((watch_dir, file_name)) = split_watch_target(&path) else {
+        return;
     };
 
     let (tx, rx) = std::sync::mpsc::channel::<()>();
+    spawn_watcher_thread(watch_dir, file_name, tx);
+    install_reload_timer(path, provider.clone(), rx);
+}
 
+/// Splits a CSS path into (parent_dir, filename). Logs and returns None
+/// if either component is missing.
+fn split_watch_target(path: &Path) -> Option<(std::path::PathBuf, std::ffi::OsString)> {
+    let watch_dir = path.parent().map(|d| d.to_path_buf()).or_else(|| {
+        log::debug!(
+            "CSS watch skipped: no parent directory for {}",
+            path.display()
+        );
+        None
+    })?;
+    let file_name = path.file_name().map(|n| n.to_os_string()).or_else(|| {
+        log::debug!("CSS watch skipped: no filename for {}", path.display());
+        None
+    })?;
+    Some((watch_dir, file_name))
+}
+
+/// Spawns the notify watcher on a background thread. The thread runs until
+/// the process exits — there's no cleanup path, which is fine for a daemon.
+fn spawn_watcher_thread(
+    watch_dir: std::path::PathBuf,
+    file_name: std::ffi::OsString,
+    tx: std::sync::mpsc::Sender<()>,
+) {
     std::thread::spawn(move || {
         use notify::{RecursiveMode, Watcher};
-        let mut watcher = match notify::recommended_watcher(make_css_handler(file_name, tx)) {
-            Ok(w) => w,
-            Err(e) => {
-                log::warn!("Failed to create CSS watcher: {}", e);
-                return;
-            }
+        let Ok(mut watcher) = notify::recommended_watcher(make_css_handler(file_name, tx))
+            .inspect_err(|e| log::warn!("Failed to create CSS watcher: {}", e))
+        else {
+            return;
         };
         if let Err(e) = watcher.watch(&watch_dir, RecursiveMode::NonRecursive) {
             log::warn!(
@@ -103,35 +110,64 @@ pub fn watch_css(css_path: &Path, provider: &gtk4::CssProvider) {
             std::thread::park();
         }
     });
+}
 
-    // Debounced reload on the GTK main thread
-    let path_reload = path.clone();
+/// Installs a debounced GLib timer that reloads the provider when
+/// the watcher signals a file change. Stops the source on disconnect.
+fn install_reload_timer(
+    path: std::path::PathBuf,
+    provider: gtk4::CssProvider,
+    rx: std::sync::mpsc::Receiver<()>,
+) {
     gtk4::glib::timeout_add_local(
         std::time::Duration::from_millis(CSS_RELOAD_DEBOUNCE_MS),
-        move || {
-            let mut changed = false;
-            loop {
-                match rx.try_recv() {
-                    Ok(()) => changed = true,
-                    Err(TryRecvError::Empty) => break,
-                    Err(TryRecvError::Disconnected) => {
-                        log::warn!("CSS watcher disconnected; stopping hot-reload");
-                        return gtk4::glib::ControlFlow::Break;
-                    }
-                }
+        move || match drain_events(&rx) {
+            DrainResult::Changed => {
+                reload_provider(&provider, &path);
+                gtk4::glib::ControlFlow::Continue
             }
-            if changed {
-                log::info!("CSS file changed, reloading: {}", path_reload.display());
-                if path_reload.exists() {
-                    provider.load_from_path(&path_reload);
-                } else {
-                    // File deleted — clear user styles so defaults show through
-                    provider.load_from_data("");
-                }
+            DrainResult::Empty => gtk4::glib::ControlFlow::Continue,
+            DrainResult::Disconnected => {
+                log::warn!("CSS watcher disconnected; stopping hot-reload");
+                gtk4::glib::ControlFlow::Break
             }
-            gtk4::glib::ControlFlow::Continue
         },
     );
+}
+
+enum DrainResult {
+    Changed,
+    Empty,
+    Disconnected,
+}
+
+/// Drains all pending events from the watcher channel.
+fn drain_events(rx: &std::sync::mpsc::Receiver<()>) -> DrainResult {
+    let mut changed = false;
+    loop {
+        match rx.try_recv() {
+            Ok(()) => changed = true,
+            Err(TryRecvError::Empty) => {
+                return if changed {
+                    DrainResult::Changed
+                } else {
+                    DrainResult::Empty
+                };
+            }
+            Err(TryRecvError::Disconnected) => return DrainResult::Disconnected,
+        }
+    }
+}
+
+/// Reloads the CSS provider from the file, or clears it if the file is gone.
+fn reload_provider(provider: &gtk4::CssProvider, path: &Path) {
+    log::info!("CSS file changed, reloading: {}", path.display());
+    if path.exists() {
+        provider.load_from_path(path);
+    } else {
+        // File deleted — clear user styles so defaults show through
+        provider.load_from_data("");
+    }
 }
 
 /// Creates a notify event handler that sends on the channel when the
@@ -152,10 +188,8 @@ fn make_css_handler(
             .paths
             .iter()
             .any(|p| p.file_name().is_some_and(|name| name == file_name));
-        if matches_file {
-            if let Err(e) = tx.send(()) {
-                log::warn!("CSS watcher channel closed: {}", e);
-            }
+        if matches_file && let Err(e) = tx.send(()) {
+            log::warn!("CSS watcher channel closed: {}", e);
         }
     }
 }

--- a/crates/nwg-drawer/src/main.rs
+++ b/crates/nwg-drawer/src/main.rs
@@ -41,7 +41,7 @@ fn main() {
     handle_existing_instance(&config);
     let _lock = acquire_singleton_lock();
     let compositor: Rc<dyn nwg_dock_common::compositor::Compositor> =
-        Rc::from(nwg_dock_common::compositor::init_or_exit(config.wm));
+        Rc::from(nwg_dock_common::compositor::init_or_null(config.wm));
 
     let sig_rx = Rc::new(signals::setup_signal_handlers(config.resident));
     let config_dir = paths::config_dir("nwg-drawer");


### PR DESCRIPTION
## Summary
- Add `NullCompositor` stub in `nwg-dock-common/src/compositor/null.rs` that implements the `Compositor` trait for environments without Hyprland/Sway IPC
- New `init_or_null()` function returns the fallback instead of hard-exiting when no supported compositor is detected
- Drawer (`nwg-drawer`) now uses `init_or_null()`, so it runs on Niri, river, Openbox, etc.
- Dock and notifications keep `init_or_exit()` — they genuinely need compositor IPC for cursor polling, window tracking, and focused-monitor popup placement
- Refactor `watch_css` to reduce cognitive complexity (separate commit)

Fixes #56

## How the fallback works

`NullCompositor` returns errors for compositor queries — the drawer already handles those gracefully:
- `get_active_window()` → error → focus-based auto-close becomes a no-op (use Escape instead)
- `list_monitors()` → error → `--output` flag falls back to GTK's default monitor
- `exec()` → routes through direct process spawn via `launch_command`, so app launching still works
- `event_stream()` → returns a no-op stream (drawer doesn't subscribe to events anyway)

## Test plan
- [x] 237 unit tests pass (8 new NullCompositor tests, including `/bin/true` spawn verification)
- [x] Clippy zero warnings (including fixing a pre-existing one in css.rs)
- [x] SonarQube zero issues
- [x] Manual smoke test on Hyprland: drawer, search, launch, middle-click, category filter, focus detection, Escape, power bar — no regressions
- [ ] Needs verification by @nwg-piotr on Niri

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now falls back to a safe "no-compositor" mode instead of exiting when compositor IPC is unavailable. Core UI remains active; compositor-dependent actions report as unavailable, cursor position is disabled, and non-empty command execution still works.

* **Refactor**
  * Improved CSS loading and file-watch handling for more robust reloads and clearer logging when styles are missing or changed.

* **Tests**
  * Added tests validating fallback behavior and command execution handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->