### PR TITLE
Fullscreen suppression + theming docs (#54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,79 @@ make sonar             # SonarQube scan (requires sonar-scanner + .env token)
 
 Both dock and drawer read/write `~/.cache/mac-dock-pinned`. Changes are detected instantly via inotify. Pin an app from either the dock (right-click → Pin) or the drawer (right-click any app). Drag icons in the dock to reorder; drag off to unpin.
 
+## Theming
+
+Both the dock and the drawer load CSS from user-writable config files. Changes are picked up **instantly via inotify** — no restart, no signal, no reload command needed. Just save the file and the new styles apply live.
+
+### CSS file locations
+
+| Binary | Path |
+|--------|------|
+| `nwg-dock-hyprland` | `~/.config/nwg-dock-hyprland/style.css` |
+| `nwg-drawer` | `~/.config/nwg-drawer/drawer.css` |
+
+Override with `-s /path/to/custom.css` if you prefer a different location.
+
+### Priority layers
+
+Three CSS layers are stacked, highest priority last:
+
+1. **Embedded defaults** — compact button sizing, indicator spacing, etc.
+2. **Programmatic overrides** — `--opacity` and bounce animation keyframes
+3. **Your CSS file** — always wins
+
+This means your CSS file can override anything, including the `--opacity` flag. If you set `background-color` in your file, that's what you get.
+
+### Smooth transitions
+
+GTK4 supports `transition:` properties on most CSS properties. Add them to your own CSS for smooth hover effects, state changes, etc:
+
+```css
+button {
+    transition: background-color 200ms ease, opacity 200ms ease;
+}
+```
+
+### base16 themes via tinty
+
+[tinty](https://github.com/tinted-theming/tinty) is a base16 theme manager. Combined with [@BlueInGreen68's base16-nwg-dock](https://git.sr.ht/~blueingreen/base16-nwg-dock) templates, you can switch themes live across your whole system.
+
+**Setup** (one-time):
+
+```bash
+# Install tinty
+cargo install tinty
+
+# Initialize config
+tinty init
+
+# Add the base16-nwg-dock templates to ~/.config/tinted-theming/tinty/config.toml:
+```
+
+```toml
+[[items]]
+name = "base16-nwg-dock-hyprland"
+path = "https://git.sr.ht/~blueingreen/base16-nwg-dock"
+themes-dir = "themes"
+hook = "cp '%f' ~/.config/nwg-dock-hyprland/style.css"
+supported-systems = ["base16"]
+
+[[items]]
+name = "base16-nwg-drawer"
+path = "https://git.sr.ht/~blueingreen/base16-nwg-dock"
+themes-dir = "themes"
+hook = "cp '%f' ~/.config/nwg-drawer/drawer.css"
+supported-systems = ["base16"]
+```
+
+**Apply a theme**:
+
+```bash
+tinty apply base16-tokyo-night-dark
+```
+
+The dock and drawer will update **instantly** — no restart required. Pair with tinty's `apply` hook on other apps (foot, waybar, alacritty, etc.) to retheme your whole session with one command.
+
 ## Deviations from Go originals
 
 Intentional differences from the original Go nwg-dock-hyprland and nwg-drawer:

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Both dock and drawer read/write `~/.cache/mac-dock-pinned`. Changes are detected
 
 ## Theming
 
-Both the dock and the drawer load CSS from user-writable config files. Changes are picked up **instantly via inotify** — no restart, no signal, no reload command needed. Just save the file and the new styles apply live.
+Both the dock and the drawer load CSS from user-writable config files. Changes are picked up **instantly via live file-change detection** (powered by the `notify` crate) — no restart, no signal, no reload command needed. Just save the file and the new styles apply live.
 
 ### CSS file locations
 

--- a/crates/nwg-dock/src/config.rs
+++ b/crates/nwg-dock/src/config.rs
@@ -163,7 +163,7 @@ pub struct DockConfig {
     #[arg(long)]
     pub launch_animation: bool,
 
-    /// Keep the dock hidden on monitors with a fullscreen window
+    /// Disable fullscreen suppression (allow dock hotspot on fullscreen monitors)
     #[arg(long)]
     pub no_fullscreen_suppress: bool,
 

--- a/crates/nwg-dock/src/config.rs
+++ b/crates/nwg-dock/src/config.rs
@@ -163,6 +163,10 @@ pub struct DockConfig {
     #[arg(long)]
     pub launch_animation: bool,
 
+    /// Keep the dock hidden on monitors with a fullscreen window
+    #[arg(long)]
+    pub no_fullscreen_suppress: bool,
+
     /// Window manager override (auto-detected from environment if not specified)
     #[arg(long, value_enum)]
     pub wm: Option<nwg_dock_common::compositor::WmOverride>,
@@ -317,6 +321,19 @@ mod tests {
     fn launch_animation_flag() {
         let config = DockConfig::parse_from(["test", "--launch-animation"]);
         assert!(config.launch_animation);
+    }
+
+    #[test]
+    fn fullscreen_suppress_default_on() {
+        // Default behavior: suppress on fullscreen (flag is opt-out)
+        let config = DockConfig::parse_from(["test"]);
+        assert!(!config.no_fullscreen_suppress);
+    }
+
+    #[test]
+    fn fullscreen_suppress_flag() {
+        let config = DockConfig::parse_from(["test", "--no-fullscreen-suppress"]);
+        assert!(config.no_fullscreen_suppress);
     }
 
     #[test]

--- a/crates/nwg-dock/src/ui/hotspot/cursor_poller.rs
+++ b/crates/nwg-dock/src/ui/hotspot/cursor_poller.rs
@@ -99,6 +99,7 @@ pub(super) fn start_cursor_poller(
                 position,
                 docks: &docks,
                 state: &state,
+                compositor: &compositor,
                 left_at: &left_at,
                 suppress_on_fullscreen,
                 hide_timeout,
@@ -119,10 +120,15 @@ pub(super) fn start_cursor_poller(
 /// Keeps signatures clean as we add more per-monitor checks over time.
 struct PollContext<'a> {
     cursor: &'a CursorPos,
+    /// Cached monitor geometry — refreshed every ~10s or on topology change.
+    /// Good enough for edge detection and bounds math, but the
+    /// `active_workspace` field can be stale. Use `compositor` for fresh
+    /// workspace-sensitive queries.
     monitors: &'a [WmMonitor],
     position: crate::config::Position,
     docks: &'a Rc<RefCell<Vec<MonitorDock>>>,
     state: &'a Rc<RefCell<DockState>>,
+    compositor: &'a Rc<dyn Compositor>,
     left_at: &'a Rc<RefCell<Option<std::time::Instant>>>,
     suppress_on_fullscreen: bool,
     hide_timeout: u64,
@@ -137,14 +143,40 @@ fn handle_hidden_dock(ctx: &PollContext<'_>) {
     let Some(mon_name) = find_cursor_monitor_name(ctx.cursor, ctx.monitors) else {
         return;
     };
-    if ctx.suppress_on_fullscreen {
-        let s = ctx.state.borrow();
-        if monitor_has_fullscreen(&s.clients, ctx.monitors, &mon_name) {
-            return;
-        }
+    if ctx.suppress_on_fullscreen && fresh_fullscreen_check(ctx, &mon_name) {
+        return;
     }
     show_on_monitor_only_by_name(ctx.docks, &mon_name);
     *ctx.left_at.borrow_mut() = None;
+}
+
+/// Fetches fresh monitor + client state from the compositor and checks for
+/// a fullscreen window on the named monitor's active workspace.
+///
+/// The cached `monitors` slice in `PollContext` can be up to ~10s stale on
+/// the `active_workspace` field, which would cause workspace-scoped
+/// suppression to make wrong decisions after a workspace switch. This
+/// function queries fresh state at the decision point.
+///
+/// Runs only when the cursor is actually at an edge (rare), so the extra
+/// IPC calls are acceptable. On query failure we return false — better to
+/// briefly flash the dock than to permanently suppress it from a stale read.
+fn fresh_fullscreen_check(ctx: &PollContext<'_>, monitor_name: &str) -> bool {
+    let fresh_monitors = match ctx.compositor.list_monitors() {
+        Ok(m) => m,
+        Err(e) => {
+            log::debug!("Fresh monitor query for fullscreen check failed: {}", e);
+            return false;
+        }
+    };
+    let fresh_clients = match ctx.compositor.list_clients() {
+        Ok(c) => c,
+        Err(e) => {
+            log::debug!("Fresh client query for fullscreen check failed: {}", e);
+            return false;
+        }
+    };
+    monitor_has_fullscreen(&fresh_clients, &fresh_monitors, monitor_name)
 }
 
 /// Returns true if any client on the named monitor's active workspace is
@@ -179,23 +211,20 @@ fn handle_visible_dock(ctx: &PollContext<'_>) {
     update_drag_state(ctx.state, dragging, in_dock_area, at_edge);
 
     // Cursor is at edge of a different monitor — migrate dock there (macOS behavior).
-    // Skip the migration if the target monitor has a fullscreen window; hide instead
-    // so dragging across screens doesn't flash the dock over a game (issue #54).
+    // Skip the migration if the target monitor has a fullscreen window on its
+    // active workspace; hide instead so dragging across screens doesn't flash
+    // the dock over a game (issue #54).
     if at_edge
         && !in_dock_area
         && !keep_visible
         && let Some(mon_name) = find_cursor_monitor_name(ctx.cursor, ctx.monitors)
     {
-        if ctx.suppress_on_fullscreen {
-            let s = ctx.state.borrow();
-            if monitor_has_fullscreen(&s.clients, ctx.monitors, &mon_name) {
-                drop(s);
-                for dock in ctx.docks.borrow().iter() {
-                    dock.win.set_visible(false);
-                }
-                *ctx.left_at.borrow_mut() = None;
-                return;
+        if ctx.suppress_on_fullscreen && fresh_fullscreen_check(ctx, &mon_name) {
+            for dock in ctx.docks.borrow().iter() {
+                dock.win.set_visible(false);
             }
+            *ctx.left_at.borrow_mut() = None;
+            return;
         }
         show_on_monitor_only_by_name(ctx.docks, &mon_name);
         *ctx.left_at.borrow_mut() = None;

--- a/crates/nwg-dock/src/ui/hotspot/cursor_poller.rs
+++ b/crates/nwg-dock/src/ui/hotspot/cursor_poller.rs
@@ -147,24 +147,22 @@ fn handle_hidden_dock(ctx: &PollContext<'_>) {
     *ctx.left_at.borrow_mut() = None;
 }
 
-/// Returns true if any client on the named monitor is fullscreen.
-/// Matches via the compositor's monitor id (stable across hotplug on
-/// the same session) rather than the name string directly.
+/// Returns true if any client on the named monitor's active workspace is
+/// fullscreen. Scoped to the active workspace so a fullscreen window parked
+/// on a hidden workspace doesn't suppress the dock on the visible one.
 fn monitor_has_fullscreen(
     clients: &[nwg_dock_common::compositor::WmClient],
     monitors: &[WmMonitor],
     monitor_name: &str,
 ) -> bool {
-    let Some(mon_id) = monitors
-        .iter()
-        .find(|m| m.name == monitor_name)
-        .map(|m| m.id)
-    else {
+    let Some(mon) = monitors.iter().find(|m| m.name == monitor_name) else {
         return false;
     };
-    clients
-        .iter()
-        .any(|c| c.fullscreen && c.monitor_id == mon_id)
+    let mon_id = mon.id;
+    let active_ws_id = mon.active_workspace.id;
+    clients.iter().any(|c| {
+        c.fullscreen && c.monitor_id == mon_id && c.workspace.id == active_ws_id
+    })
 }
 
 /// Handles cursor polling when the dock is visible: hides after timeout if cursor leaves.
@@ -356,6 +354,18 @@ mod tests {
     }
 
     fn test_monitor_with_id(id: i32, name: &str, x: i32, y: i32, w: i32, h: i32) -> WmMonitor {
+        test_monitor_with_workspace(id, name, x, y, w, h, 0)
+    }
+
+    fn test_monitor_with_workspace(
+        id: i32,
+        name: &str,
+        x: i32,
+        y: i32,
+        w: i32,
+        h: i32,
+        active_workspace_id: i32,
+    ) -> WmMonitor {
         WmMonitor {
             id,
             name: name.to_string(),
@@ -365,18 +375,29 @@ mod tests {
             height: h,
             scale: 1.0,
             focused: false,
-            active_workspace: WmWorkspace::default(),
+            active_workspace: WmWorkspace {
+                id: active_workspace_id,
+                name: format!("{}", active_workspace_id),
+            },
         }
     }
 
     fn test_client(monitor_id: i32, fullscreen: bool) -> WmClient {
+        // Workspace id 0 matches the default active workspace on test_monitor_with_id
+        test_client_on_workspace(monitor_id, fullscreen, 0)
+    }
+
+    fn test_client_on_workspace(monitor_id: i32, fullscreen: bool, workspace_id: i32) -> WmClient {
         WmClient {
             id: format!("0x{}", monitor_id),
             class: "test".into(),
             initial_class: "test".into(),
             title: "test".into(),
             pid: 1,
-            workspace: WmWorkspace::default(),
+            workspace: WmWorkspace {
+                id: workspace_id,
+                name: format!("{}", workspace_id),
+            },
             floating: false,
             monitor_id,
             fullscreen,
@@ -521,6 +542,10 @@ mod tests {
     const HDMI_W: i32 = 2560;
     const HDMI_H: i32 = 1440;
     const UNKNOWN_MONITOR: &str = "DP-9";
+    // Workspace ids for the workspace-scoped regression test.
+    // Values are arbitrary — only the fact that VISIBLE_WS != HIDDEN_WS matters.
+    const VISIBLE_WS: i32 = 1;
+    const HIDDEN_WS: i32 = 2;
 
     fn dp1_monitor() -> WmMonitor {
         test_monitor_with_id(DP1_ID, DP1_NAME, 0, 0, DP1_W, DP1_H)
@@ -565,5 +590,32 @@ mod tests {
         let clients = vec![test_client(DP1_ID, true)];
         // Asking about a monitor that doesn't exist — must not panic or suppress.
         assert!(!monitor_has_fullscreen(&clients, &monitors, UNKNOWN_MONITOR));
+    }
+
+    #[test]
+    fn fullscreen_on_hidden_workspace_not_suppressed() {
+        // Regression test: a fullscreen window parked on a workspace that
+        // isn't currently visible on the monitor must NOT suppress the dock
+        // on the visible workspace. Without workspace scoping, this would
+        // incorrectly match and hide the dock.
+        let monitors = vec![test_monitor_with_workspace(
+            DP1_ID, DP1_NAME, 0, 0, DP1_W, DP1_H, VISIBLE_WS,
+        )];
+        let clients = vec![test_client_on_workspace(DP1_ID, true, HIDDEN_WS)];
+        assert!(
+            !monitor_has_fullscreen(&clients, &monitors, DP1_NAME),
+            "fullscreen on hidden workspace must not suppress dock on visible one"
+        );
+    }
+
+    #[test]
+    fn fullscreen_on_active_workspace_suppressed() {
+        // Complement to the above: fullscreen on the currently active
+        // workspace must still suppress as expected.
+        let monitors = vec![test_monitor_with_workspace(
+            DP1_ID, DP1_NAME, 0, 0, DP1_W, DP1_H, VISIBLE_WS,
+        )];
+        let clients = vec![test_client_on_workspace(DP1_ID, true, VISIBLE_WS)];
+        assert!(monitor_has_fullscreen(&clients, &monitors, DP1_NAME));
     }
 }

--- a/crates/nwg-dock/src/ui/hotspot/cursor_poller.rs
+++ b/crates/nwg-dock/src/ui/hotspot/cursor_poller.rs
@@ -180,12 +180,25 @@ fn handle_visible_dock(ctx: &PollContext<'_>) {
 
     update_drag_state(ctx.state, dragging, in_dock_area, at_edge);
 
-    // Cursor is at edge of a different monitor — migrate dock there (macOS behavior)
+    // Cursor is at edge of a different monitor — migrate dock there (macOS behavior).
+    // Skip the migration if the target monitor has a fullscreen window; hide instead
+    // so dragging across screens doesn't flash the dock over a game (issue #54).
     if at_edge
         && !in_dock_area
         && !keep_visible
         && let Some(mon_name) = find_cursor_monitor_name(ctx.cursor, ctx.monitors)
     {
+        if ctx.suppress_on_fullscreen {
+            let s = ctx.state.borrow();
+            if monitor_has_fullscreen(&s.clients, ctx.monitors, &mon_name) {
+                drop(s);
+                for dock in ctx.docks.borrow().iter() {
+                    dock.win.set_visible(false);
+                }
+                *ctx.left_at.borrow_mut() = None;
+                return;
+            }
+        }
         show_on_monitor_only_by_name(ctx.docks, &mon_name);
         *ctx.left_at.borrow_mut() = None;
         return;

--- a/crates/nwg-dock/src/ui/hotspot/cursor_poller.rs
+++ b/crates/nwg-dock/src/ui/hotspot/cursor_poller.rs
@@ -93,26 +93,21 @@ pub(super) fn start_cursor_poller(
 
             let any_visible = docks.borrow().iter().any(|d| d.win.is_visible());
 
+            let ctx = PollContext {
+                cursor: &cursor,
+                monitors: &monitors,
+                position,
+                docks: &docks,
+                state: &state,
+                left_at: &left_at,
+                suppress_on_fullscreen,
+                hide_timeout,
+            };
+
             if !any_visible {
-                handle_hidden_dock(
-                    &cursor,
-                    &monitors,
-                    position,
-                    &docks,
-                    &state,
-                    suppress_on_fullscreen,
-                    &left_at,
-                );
+                handle_hidden_dock(&ctx);
             } else {
-                handle_visible_dock(
-                    &cursor,
-                    &monitors,
-                    position,
-                    &docks,
-                    &state,
-                    &left_at,
-                    hide_timeout,
-                );
+                handle_visible_dock(&ctx);
             }
 
             glib::ControlFlow::Continue
@@ -120,31 +115,36 @@ pub(super) fn start_cursor_poller(
     );
 }
 
+/// Bundles the references needed by the cursor poller's per-tick handlers.
+/// Keeps signatures clean as we add more per-monitor checks over time.
+struct PollContext<'a> {
+    cursor: &'a CursorPos,
+    monitors: &'a [WmMonitor],
+    position: crate::config::Position,
+    docks: &'a Rc<RefCell<Vec<MonitorDock>>>,
+    state: &'a Rc<RefCell<DockState>>,
+    left_at: &'a Rc<RefCell<Option<std::time::Instant>>>,
+    suppress_on_fullscreen: bool,
+    hide_timeout: u64,
+}
+
 /// Handles cursor polling when the dock is hidden: shows the dock if cursor is at edge.
 /// Skips showing if a fullscreen window occupies the target monitor (issue #54).
-fn handle_hidden_dock(
-    cursor: &CursorPos,
-    monitors: &[WmMonitor],
-    position: crate::config::Position,
-    docks: &Rc<RefCell<Vec<MonitorDock>>>,
-    state: &Rc<RefCell<DockState>>,
-    suppress_on_fullscreen: bool,
-    left_at: &Rc<RefCell<Option<std::time::Instant>>>,
-) {
-    if !is_cursor_at_edge(cursor, monitors, position) {
+fn handle_hidden_dock(ctx: &PollContext<'_>) {
+    if !is_cursor_at_edge(ctx.cursor, ctx.monitors, ctx.position) {
         return;
     }
-    let Some(mon_name) = find_cursor_monitor_name(cursor, monitors) else {
+    let Some(mon_name) = find_cursor_monitor_name(ctx.cursor, ctx.monitors) else {
         return;
     };
-    if suppress_on_fullscreen {
-        let s = state.borrow();
-        if monitor_has_fullscreen(&s.clients, monitors, &mon_name) {
+    if ctx.suppress_on_fullscreen {
+        let s = ctx.state.borrow();
+        if monitor_has_fullscreen(&s.clients, ctx.monitors, &mon_name) {
             return;
         }
     }
-    show_on_monitor_only_by_name(docks, &mon_name);
-    *left_at.borrow_mut() = None;
+    show_on_monitor_only_by_name(ctx.docks, &mon_name);
+    *ctx.left_at.borrow_mut() = None;
 }
 
 /// Returns true if any client on the named monitor is fullscreen.
@@ -168,41 +168,33 @@ fn monitor_has_fullscreen(
 }
 
 /// Handles cursor polling when the dock is visible: hides after timeout if cursor leaves.
-fn handle_visible_dock(
-    cursor: &CursorPos,
-    monitors: &[WmMonitor],
-    position: crate::config::Position,
-    docks: &Rc<RefCell<Vec<MonitorDock>>>,
-    state: &Rc<RefCell<DockState>>,
-    left_at: &Rc<RefCell<Option<std::time::Instant>>>,
-    hide_timeout: u64,
-) {
-    let in_dock_area = is_cursor_in_visible_dock(cursor, docks, monitors, position);
-    let at_edge = is_cursor_at_edge(cursor, monitors, position);
+fn handle_visible_dock(ctx: &PollContext<'_>) {
+    let in_dock_area = is_cursor_in_visible_dock(ctx.cursor, ctx.docks, ctx.monitors, ctx.position);
+    let at_edge = is_cursor_at_edge(ctx.cursor, ctx.monitors, ctx.position);
 
     // Don't hide while a popover menu is open or a drag is in progress
-    let s = state.borrow();
+    let s = ctx.state.borrow();
     let dragging = s.drag_pending || s.drag_source_index.is_some();
     let keep_visible = s.popover_open || dragging;
     drop(s);
 
-    update_drag_state(state, dragging, in_dock_area, at_edge);
+    update_drag_state(ctx.state, dragging, in_dock_area, at_edge);
 
     // Cursor is at edge of a different monitor — migrate dock there (macOS behavior)
     if at_edge
         && !in_dock_area
         && !keep_visible
-        && let Some(mon_name) = find_cursor_monitor_name(cursor, monitors)
+        && let Some(mon_name) = find_cursor_monitor_name(ctx.cursor, ctx.monitors)
     {
-        show_on_monitor_only_by_name(docks, &mon_name);
-        *left_at.borrow_mut() = None;
+        show_on_monitor_only_by_name(ctx.docks, &mon_name);
+        *ctx.left_at.borrow_mut() = None;
         return;
     }
 
     if in_dock_area || at_edge || keep_visible {
-        *left_at.borrow_mut() = None;
+        *ctx.left_at.borrow_mut() = None;
     } else {
-        check_hide_timer(docks, left_at, hide_timeout);
+        check_hide_timer(ctx.docks, ctx.left_at, ctx.hide_timeout);
     }
 }
 
@@ -503,44 +495,62 @@ mod tests {
         ));
     }
 
+    // Fixture constants for the fullscreen suppression tests —
+    // the specific values don't matter, but having names makes the
+    // intent obvious and avoids magic literals.
+    const DP1_ID: i32 = 0;
+    const DP1_NAME: &str = "DP-1";
+    const DP1_W: i32 = 1920;
+    const DP1_H: i32 = 1080;
+    const HDMI_ID: i32 = 1;
+    const HDMI_NAME: &str = "HDMI-A-1";
+    const HDMI_X: i32 = 1920;
+    const HDMI_W: i32 = 2560;
+    const HDMI_H: i32 = 1440;
+    const UNKNOWN_MONITOR: &str = "DP-9";
+
+    fn dp1_monitor() -> WmMonitor {
+        test_monitor_with_id(DP1_ID, DP1_NAME, 0, 0, DP1_W, DP1_H)
+    }
+
     #[test]
     fn fullscreen_empty_clients_not_suppressed() {
-        let monitors = vec![test_monitor_with_id(0, "DP-1", 0, 0, 1920, 1080)];
-        assert!(!monitor_has_fullscreen(&[], &monitors, "DP-1"));
+        let monitors = vec![dp1_monitor()];
+        assert!(!monitor_has_fullscreen(&[], &monitors, DP1_NAME));
     }
 
     #[test]
     fn fullscreen_non_fullscreen_client_not_suppressed() {
-        let monitors = vec![test_monitor_with_id(0, "DP-1", 0, 0, 1920, 1080)];
-        let clients = vec![test_client(0, false)];
-        assert!(!monitor_has_fullscreen(&clients, &monitors, "DP-1"));
+        let monitors = vec![dp1_monitor()];
+        let clients = vec![test_client(DP1_ID, false)];
+        assert!(!monitor_has_fullscreen(&clients, &monitors, DP1_NAME));
     }
 
     #[test]
     fn fullscreen_matching_monitor_suppressed() {
-        let monitors = vec![test_monitor_with_id(0, "DP-1", 0, 0, 1920, 1080)];
-        let clients = vec![test_client(0, true)];
-        assert!(monitor_has_fullscreen(&clients, &monitors, "DP-1"));
+        let monitors = vec![dp1_monitor()];
+        let clients = vec![test_client(DP1_ID, true)];
+        assert!(monitor_has_fullscreen(&clients, &monitors, DP1_NAME));
     }
 
     #[test]
     fn fullscreen_other_monitor_not_suppressed() {
-        // Fullscreen on monitor 1, but we're asking about monitor 0 (DP-1).
+        // Fullscreen on HDMI, but we're asking about DP-1.
         // Must not suppress — per-monitor check means other monitors are unaffected.
         let monitors = vec![
-            test_monitor_with_id(0, "DP-1", 0, 0, 1920, 1080),
-            test_monitor_with_id(1, "HDMI-A-1", 1920, 0, 2560, 1440),
+            dp1_monitor(),
+            test_monitor_with_id(HDMI_ID, HDMI_NAME, HDMI_X, 0, HDMI_W, HDMI_H),
         ];
-        let clients = vec![test_client(1, true)]; // fullscreen on HDMI-A-1
-        assert!(!monitor_has_fullscreen(&clients, &monitors, "DP-1"));
-        assert!(monitor_has_fullscreen(&clients, &monitors, "HDMI-A-1"));
+        let clients = vec![test_client(HDMI_ID, true)];
+        assert!(!monitor_has_fullscreen(&clients, &monitors, DP1_NAME));
+        assert!(monitor_has_fullscreen(&clients, &monitors, HDMI_NAME));
     }
 
     #[test]
     fn fullscreen_unknown_monitor_not_suppressed() {
-        let monitors = vec![test_monitor_with_id(0, "DP-1", 0, 0, 1920, 1080)];
-        let clients = vec![test_client(0, true)];
+        let monitors = vec![dp1_monitor()];
+        let clients = vec![test_client(DP1_ID, true)];
         // Asking about a monitor that doesn't exist — must not panic or suppress.
-        assert!(!monitor_has_fullscreen(&clients, &monitors, "DP-9"));
+        assert!(!monitor_has_fullscreen(&clients, &monitors, UNKNOWN_MONITOR));
     }
 }

--- a/crates/nwg-dock/src/ui/hotspot/cursor_poller.rs
+++ b/crates/nwg-dock/src/ui/hotspot/cursor_poller.rs
@@ -29,6 +29,7 @@ pub(super) fn start_cursor_poller(
     let docks = Rc::clone(per_monitor);
     let position = config.position;
     let hide_timeout = config.hide_timeout;
+    let suppress_on_fullscreen = !config.no_fullscreen_suppress;
     let state = Rc::clone(state);
     let compositor = Rc::clone(compositor);
     // Track when cursor last left the dock area (for hide delay)
@@ -93,7 +94,15 @@ pub(super) fn start_cursor_poller(
             let any_visible = docks.borrow().iter().any(|d| d.win.is_visible());
 
             if !any_visible {
-                handle_hidden_dock(&cursor, &monitors, position, &docks, &left_at);
+                handle_hidden_dock(
+                    &cursor,
+                    &monitors,
+                    position,
+                    &docks,
+                    &state,
+                    suppress_on_fullscreen,
+                    &left_at,
+                );
             } else {
                 handle_visible_dock(
                     &cursor,
@@ -112,19 +121,50 @@ pub(super) fn start_cursor_poller(
 }
 
 /// Handles cursor polling when the dock is hidden: shows the dock if cursor is at edge.
+/// Skips showing if a fullscreen window occupies the target monitor (issue #54).
 fn handle_hidden_dock(
     cursor: &CursorPos,
     monitors: &[WmMonitor],
     position: crate::config::Position,
     docks: &Rc<RefCell<Vec<MonitorDock>>>,
+    state: &Rc<RefCell<DockState>>,
+    suppress_on_fullscreen: bool,
     left_at: &Rc<RefCell<Option<std::time::Instant>>>,
 ) {
-    if is_cursor_at_edge(cursor, monitors, position)
-        && let Some(mon_name) = find_cursor_monitor_name(cursor, monitors)
-    {
-        show_on_monitor_only_by_name(docks, &mon_name);
-        *left_at.borrow_mut() = None;
+    if !is_cursor_at_edge(cursor, monitors, position) {
+        return;
     }
+    let Some(mon_name) = find_cursor_monitor_name(cursor, monitors) else {
+        return;
+    };
+    if suppress_on_fullscreen {
+        let s = state.borrow();
+        if monitor_has_fullscreen(&s.clients, monitors, &mon_name) {
+            return;
+        }
+    }
+    show_on_monitor_only_by_name(docks, &mon_name);
+    *left_at.borrow_mut() = None;
+}
+
+/// Returns true if any client on the named monitor is fullscreen.
+/// Matches via the compositor's monitor id (stable across hotplug on
+/// the same session) rather than the name string directly.
+fn monitor_has_fullscreen(
+    clients: &[nwg_dock_common::compositor::WmClient],
+    monitors: &[WmMonitor],
+    monitor_name: &str,
+) -> bool {
+    let Some(mon_id) = monitors
+        .iter()
+        .find(|m| m.name == monitor_name)
+        .map(|m| m.id)
+    else {
+        return false;
+    };
+    clients
+        .iter()
+        .any(|c| c.fullscreen && c.monitor_id == mon_id)
 }
 
 /// Handles cursor polling when the dock is visible: hides after timeout if cursor leaves.
@@ -304,11 +344,15 @@ fn is_cursor_in_visible_dock(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nwg_dock_common::compositor::WmWorkspace;
+    use nwg_dock_common::compositor::{WmClient, WmWorkspace};
 
     fn test_monitor(name: &str, x: i32, y: i32, w: i32, h: i32) -> WmMonitor {
+        test_monitor_with_id(0, name, x, y, w, h)
+    }
+
+    fn test_monitor_with_id(id: i32, name: &str, x: i32, y: i32, w: i32, h: i32) -> WmMonitor {
         WmMonitor {
-            id: 0,
+            id,
             name: name.to_string(),
             x,
             y,
@@ -317,6 +361,20 @@ mod tests {
             scale: 1.0,
             focused: false,
             active_workspace: WmWorkspace::default(),
+        }
+    }
+
+    fn test_client(monitor_id: i32, fullscreen: bool) -> WmClient {
+        WmClient {
+            id: format!("0x{}", monitor_id),
+            class: "test".into(),
+            initial_class: "test".into(),
+            title: "test".into(),
+            pid: 1,
+            workspace: WmWorkspace::default(),
+            floating: false,
+            monitor_id,
+            fullscreen,
         }
     }
 
@@ -443,5 +501,46 @@ mod tests {
             &monitors,
             crate::config::Position::Bottom
         ));
+    }
+
+    #[test]
+    fn fullscreen_empty_clients_not_suppressed() {
+        let monitors = vec![test_monitor_with_id(0, "DP-1", 0, 0, 1920, 1080)];
+        assert!(!monitor_has_fullscreen(&[], &monitors, "DP-1"));
+    }
+
+    #[test]
+    fn fullscreen_non_fullscreen_client_not_suppressed() {
+        let monitors = vec![test_monitor_with_id(0, "DP-1", 0, 0, 1920, 1080)];
+        let clients = vec![test_client(0, false)];
+        assert!(!monitor_has_fullscreen(&clients, &monitors, "DP-1"));
+    }
+
+    #[test]
+    fn fullscreen_matching_monitor_suppressed() {
+        let monitors = vec![test_monitor_with_id(0, "DP-1", 0, 0, 1920, 1080)];
+        let clients = vec![test_client(0, true)];
+        assert!(monitor_has_fullscreen(&clients, &monitors, "DP-1"));
+    }
+
+    #[test]
+    fn fullscreen_other_monitor_not_suppressed() {
+        // Fullscreen on monitor 1, but we're asking about monitor 0 (DP-1).
+        // Must not suppress — per-monitor check means other monitors are unaffected.
+        let monitors = vec![
+            test_monitor_with_id(0, "DP-1", 0, 0, 1920, 1080),
+            test_monitor_with_id(1, "HDMI-A-1", 1920, 0, 2560, 1440),
+        ];
+        let clients = vec![test_client(1, true)]; // fullscreen on HDMI-A-1
+        assert!(!monitor_has_fullscreen(&clients, &monitors, "DP-1"));
+        assert!(monitor_has_fullscreen(&clients, &monitors, "HDMI-A-1"));
+    }
+
+    #[test]
+    fn fullscreen_unknown_monitor_not_suppressed() {
+        let monitors = vec![test_monitor_with_id(0, "DP-1", 0, 0, 1920, 1080)];
+        let clients = vec![test_client(0, true)];
+        // Asking about a monitor that doesn't exist — must not panic or suppress.
+        assert!(!monitor_has_fullscreen(&clients, &monitors, "DP-9"));
     }
 }


### PR DESCRIPTION
## Summary
- **Fullscreen suppression (#54)** — dock autohide no longer triggers on monitors with a fullscreen window. Per-monitor: monitor A being fullscreen won't block monitor B. New `--no-fullscreen-suppress` flag opts out for users who want the dock always available.
- **Theming docs** — new "Theming" section in the README explaining the hot-reload workflow, CSS priority layers, smooth transitions, and full tinty integration steps using @BlueInGreen68's base16-nwg-dock templates.

Fixes #54
References: #46

## Implementation notes

- `monitor_has_fullscreen(clients, monitors, name)` is the core check — pure function taking slices so it's trivially unit-testable without mocking a full `DockState`
- Threaded through as a bool flag into `handle_hidden_dock` so the state borrow happens only when suppression is enabled
- 7 new tests covering: empty clients, non-fullscreen client, matching monitor, other monitor (per-monitor isolation), unknown monitor name

## Test plan
- [x] 244 unit tests pass (7 new for suppression logic + 2 for CLI flag)
- [x] Clippy zero warnings
- [x] SonarQube zero issues on changed files
- [x] Manual: Started a game — dock stayed hidden through the entire session, reappeared as normal after exit
- [x] Manual: Regular (non-fullscreen) apps still trigger the dock on hotspot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Theming section: live CSS theming for dock/drawer, CSS priority rules, GTK4 transition examples, and a base16 tinty workflow with instant apply.

* **New Features**
  * Added CLI option --no-fullscreen-suppress to let the dock appear even when fullscreen windows exist.

* **Bug Fixes / Behavior**
  * Improved fullscreen detection and monitor/workspace-aware hiding/migration so the dock respects fullscreen per monitor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->