### PR TITLE
Dock liveness tick + zombie surface recovery (#45, #53, #61)

### DIFF
--- a/crates/nwg-dock/src/listeners.rs
+++ b/crates/nwg-dock/src/listeners.rs
@@ -339,6 +339,20 @@ fn decide_reconcile(
     dock_names: &[String],
     dock_has_surface: &[bool],
 ) -> bool {
+    // Cardinality guard: catches duplicate dock entries (same monitor mapped to
+    // multiple windows) and parallel-array invariant violations. Simple
+    // membership checks below miss the duplicate case when the extra entry
+    // also has a GDK monitor match.
+    if gdk_names.len() != dock_names.len() || dock_names.len() != dock_has_surface.len() {
+        log::debug!(
+            "Liveness: cardinality mismatch (gdk={}, docks={}, surfaces={})",
+            gdk_names.len(),
+            dock_names.len(),
+            dock_has_surface.len()
+        );
+        return true;
+    }
+
     // Missing monitor: GDK has a connector we don't have a dock for
     for name in gdk_names {
         if !dock_names.contains(name) {
@@ -583,6 +597,29 @@ mod tests {
         let docks = names(&["DP-1"]);
         let surfaces = vec![true];
         assert!(!decide_reconcile(&expected, &docks, &surfaces));
+    }
+
+    #[test]
+    fn decide_reconcile_detects_duplicate_dock_for_same_monitor() {
+        // Defensive: if reconciliation ever produced two docks for the same
+        // monitor (startup race, double hotplug event, etc.), membership
+        // checks alone wouldn't catch it. Cardinality guard triggers a heal.
+        let gdk = names(&["DP-1"]);
+        let docks = names(&["DP-1", "DP-1"]);
+        let surfaces = vec![true, true];
+        assert!(decide_reconcile(&gdk, &docks, &surfaces));
+    }
+
+    #[test]
+    fn decide_reconcile_detects_parallel_array_invariant_violation() {
+        // Defensive: dock_names and dock_has_surface are parallel arrays
+        // populated from the same Vec iteration. If they ever get out of
+        // sync (caller bug), we must flag drift rather than silently
+        // walking off the end via zip truncation.
+        let gdk = names(&["DP-1"]);
+        let docks = names(&["DP-1"]);
+        let surfaces = vec![true, true]; // extra surface bool with no matching name
+        assert!(decide_reconcile(&gdk, &docks, &surfaces));
     }
 
     #[test]

--- a/crates/nwg-dock/src/listeners.rs
+++ b/crates/nwg-dock/src/listeners.rs
@@ -296,7 +296,7 @@ pub fn setup_liveness_tick(
     let rebuild_fn = Rc::clone(rebuild_fn);
 
     glib::timeout_add_local(LIVENESS_TICK_INTERVAL, move || {
-        if needs_reconcile(&per_monitor) {
+        if needs_reconcile(&per_monitor, &config) {
             log::info!("Liveness tick detected state drift, reconciling");
             reconcile_monitors(
                 &app,
@@ -310,32 +310,25 @@ pub fn setup_liveness_tick(
     });
 }
 
-/// Returns true if the dock's per-monitor state diverges from GDK's current
-/// monitor list, or if any existing dock has a zombie surface.
+/// Returns true if the dock's per-monitor state diverges from the monitor
+/// set this config would select, or if any existing dock has a zombie surface.
 /// Pure read-only checks — no IPC, no side effects.
-fn needs_reconcile(per_monitor: &Rc<RefCell<Vec<MonitorDock>>>) -> bool {
-    let Some(display) = gtk4::gdk::Display::default() else {
-        return false;
-    };
-    let model = display.monitors();
-
-    // Collect current GDK connector names (stable identifiers)
-    let mut current: Vec<String> = Vec::with_capacity(model.n_items() as usize);
-    for i in 0..model.n_items() {
-        if let Some(item) = model.item(i)
-            && let Ok(mon) = item.downcast::<gtk4::gdk::Monitor>()
-            && let Some(connector) = mon.connector()
-        {
-            current.push(connector.to_string());
-        }
-    }
+///
+/// Uses `monitor::resolve_monitors` (which honors `--output`) rather than the
+/// raw GDK monitor list — otherwise a single-monitor-targeted dock would
+/// perpetually "drift" against a multi-monitor GDK state.
+fn needs_reconcile(per_monitor: &Rc<RefCell<Vec<MonitorDock>>>, config: &DockConfig) -> bool {
+    let expected_names: Vec<String> = monitor::resolve_monitors(config)
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect();
 
     let docks = per_monitor.borrow();
     let dock_names: Vec<String> = docks.iter().map(|d| d.output_name.clone()).collect();
     let dock_has_surface: Vec<bool> = docks.iter().map(|d| d.win.surface().is_some()).collect();
     drop(docks);
 
-    decide_reconcile(&current, &dock_names, &dock_has_surface)
+    decide_reconcile(&expected_names, &dock_names, &dock_has_surface)
 }
 
 /// Pure decision logic for `needs_reconcile`. Testable without GTK —
@@ -579,6 +572,17 @@ mod tests {
         let docks = names(&["DP-1", "HDMI-A-1"]);
         let surfaces = vec![true, true];
         assert!(!decide_reconcile(&gdk, &docks, &surfaces));
+    }
+
+    #[test]
+    fn decide_reconcile_respects_config_output_filter() {
+        // When --output DP-1 is set, the caller passes only the config-selected
+        // monitor as `expected` — even though GDK has other monitors. A dock
+        // matching that single expected monitor must not trigger drift.
+        let expected = names(&["DP-1"]);
+        let docks = names(&["DP-1"]);
+        let surfaces = vec![true];
+        assert!(!decide_reconcile(&expected, &docks, &surfaces));
     }
 
     #[test]

--- a/crates/nwg-dock/src/listeners.rs
+++ b/crates/nwg-dock/src/listeners.rs
@@ -318,7 +318,10 @@ pub fn setup_liveness_tick(
 /// raw GDK monitor list — otherwise a single-monitor-targeted dock would
 /// perpetually "drift" against a multi-monitor GDK state.
 fn needs_reconcile(per_monitor: &Rc<RefCell<Vec<MonitorDock>>>, config: &DockConfig) -> bool {
-    let expected_names: Vec<String> = monitor::resolve_monitors(config)
+    // Quiet variant: avoid spamming the "Target output not found" warning
+    // every 2 seconds if the user's --output is mistyped. The loud variant
+    // in reconcile_monitors and startup still surfaces it.
+    let expected_names: Vec<String> = monitor::resolve_monitors_quiet(config)
         .into_iter()
         .map(|(name, _)| name)
         .collect();

--- a/crates/nwg-dock/src/listeners.rs
+++ b/crates/nwg-dock/src/listeners.rs
@@ -261,8 +261,8 @@ fn zombie_names(
 ) -> Vec<String> {
     dock_names
         .iter()
-        .zip(dock_has_surface.iter())
-        .filter(|(name, has_surface)| !**has_surface && present_names.contains(name))
+        .zip(dock_has_surface.iter().copied())
+        .filter(|(name, has_surface)| !has_surface && present_names.contains(name))
         .map(|(name, _)| name.clone())
         .collect()
 }

--- a/crates/nwg-dock/src/listeners.rs
+++ b/crates/nwg-dock/src/listeners.rs
@@ -23,6 +23,16 @@ const AUTOHIDE_INITIAL_DELAY: Duration = Duration::from_millis(500);
 /// reconciliation only fires when state actually diverges.
 const LIVENESS_TICK_INTERVAL: Duration = Duration::from_secs(2);
 
+/// Bundles the dependencies needed by the monitor watcher and liveness tick
+/// paths so entrypoint signatures stay short and consistent.
+pub struct ReconcileContext {
+    pub app: gtk4::Application,
+    pub per_monitor: Rc<RefCell<Vec<MonitorDock>>>,
+    pub config: Rc<DockConfig>,
+    pub rebuild_fn: Rc<dyn Fn()>,
+    pub hotspot_ctx: Option<Rc<crate::ui::hotspot::HotspotContext>>,
+}
+
 /// Sets up an inotify-based pin file watcher that triggers a rebuild
 /// when the pin file is modified (e.g. by the drawer).
 pub fn setup_pin_watcher(pinned_file: &Path, rebuild: &Rc<dyn Fn()>) {
@@ -131,13 +141,7 @@ pub fn setup_autohide(
 /// Uses the `items-changed` signal on `Display::monitors()` to detect
 /// monitor hotplug events. Debounced via idle callback to coalesce
 /// rapid events (e.g., unplug + replug).
-pub fn setup_monitor_watcher(
-    app: &gtk4::Application,
-    per_monitor: &Rc<RefCell<Vec<MonitorDock>>>,
-    config: &Rc<DockConfig>,
-    rebuild_fn: &Rc<dyn Fn()>,
-    hotspot_ctx: Option<Rc<crate::ui::hotspot::HotspotContext>>,
-) {
+pub fn setup_monitor_watcher(ctx: Rc<ReconcileContext>) {
     let Some(display) = gtk4::gdk::Display::default() else {
         log::error!("No default GDK display for monitor watcher");
         return;
@@ -145,10 +149,6 @@ pub fn setup_monitor_watcher(
 
     let model = display.monitors();
     let pending = Rc::new(Cell::new(false));
-    let app = app.clone();
-    let per_monitor = Rc::clone(per_monitor);
-    let config = Rc::clone(config);
-    let rebuild_fn = Rc::clone(rebuild_fn);
 
     model.connect_items_changed(move |_, _, _, _| {
         if pending.get() {
@@ -157,22 +157,12 @@ pub fn setup_monitor_watcher(
         pending.set(true);
 
         let pending = Rc::clone(&pending);
-        let app = app.clone();
-        let per_monitor = Rc::clone(&per_monitor);
-        let config = Rc::clone(&config);
-        let rebuild_fn = Rc::clone(&rebuild_fn);
-        let hotspot_ctx = hotspot_ctx.clone();
+        let ctx = Rc::clone(&ctx);
 
         glib::idle_add_local_once(move || {
             pending.set(false);
             log::info!("Monitor topology changed, reconciling dock windows");
-            reconcile_monitors(
-                &app,
-                &per_monitor,
-                &config,
-                &rebuild_fn,
-                hotspot_ctx.as_deref(),
-            );
+            reconcile_monitors(&ctx);
         });
     });
 }
@@ -180,49 +170,68 @@ pub fn setup_monitor_watcher(
 /// Reconciles dock windows with current monitor topology.
 /// Creates windows for new monitors, destroys windows for removed monitors,
 /// and rebuilds zombie windows (`surface().is_none()` — DPMS/lock cycles).
-fn reconcile_monitors(
-    app: &gtk4::Application,
-    per_monitor: &Rc<RefCell<Vec<MonitorDock>>>,
-    config: &DockConfig,
-    rebuild_fn: &Rc<dyn Fn()>,
-    hotspot_ctx: Option<&crate::ui::hotspot::HotspotContext>,
-) {
-    let current_monitors = monitor::resolve_monitors(config);
+///
+/// Zombie rebuilds and physical disconnects are handled on separate branches
+/// so log messages can clearly distinguish "compositor destroyed our surface"
+/// (a recovery) from "user unplugged a monitor" (a topology change).
+fn reconcile_monitors(ctx: &ReconcileContext) {
+    let hotspot_ctx = ctx.hotspot_ctx.as_deref();
+    let current_monitors = monitor::resolve_monitors(&ctx.config);
     let monitor_map: std::collections::HashMap<String, gtk4::gdk::Monitor> =
         current_monitors.into_iter().collect();
     let current_names: Vec<String> = monitor_map.keys().cloned().collect();
-    let existing_names: Vec<String> = per_monitor
+    let existing_names: Vec<String> = ctx
+        .per_monitor
         .borrow()
         .iter()
         .map(|d| d.output_name.clone())
         .collect();
 
-    let (mut to_add, mut to_remove) =
-        dock_windows::compute_monitor_diff(&existing_names, &current_names);
+    let (to_add, to_remove) = dock_windows::compute_monitor_diff(&existing_names, &current_names);
 
     // Always refresh GDK monitor references — a reconnected monitor with the same
     // connector name produces a new gdk::Monitor object, and the old one is stale.
-    refresh_monitor_refs(per_monitor, &monitor_map, hotspot_ctx);
+    refresh_monitor_refs(&ctx.per_monitor, &monitor_map, hotspot_ctx);
 
-    // Detect zombie windows: for monitors present in both sets, check if the
-    // dock's layer-shell surface is still valid. If not, force remove+re-add.
-    let zombies = find_zombie_docks(per_monitor, &current_names);
-    for name in &zombies {
-        log::warn!(
-            "Zombie dock detected for '{}' (surface is None), rebuilding",
-            name
-        );
-    }
-    merge_zombies_into_diff(&mut to_add, &mut to_remove, &zombies);
+    // Zombie windows: monitor still present, but layer-shell surface is gone.
+    // Kept in a separate list (not merged into to_remove) so logs can
+    // distinguish a DPMS/lock recovery from a real disconnect.
+    let zombies = find_zombie_docks(&ctx.per_monitor, &current_names);
 
-    if to_add.is_empty() && to_remove.is_empty() {
+    if to_add.is_empty() && to_remove.is_empty() && zombies.is_empty() {
         log::debug!("Monitor topology unchanged after debounce");
         return;
     }
 
-    remove_orphaned_docks(per_monitor, &to_remove, hotspot_ctx);
-    add_new_docks(app, per_monitor, &to_add, &monitor_map, config, hotspot_ctx);
-    rebuild_fn();
+    remove_zombie_docks(&ctx.per_monitor, &zombies, hotspot_ctx);
+    remove_orphaned_docks(&ctx.per_monitor, &to_remove, hotspot_ctx);
+
+    // Combine physical-add and zombie-rebuild names for the add path.
+    // Both need a fresh window with the same creation logic; only the
+    // removal logging differs.
+    let to_create = combine_add_lists(&to_add, &zombies);
+    add_new_docks(
+        &ctx.app,
+        &ctx.per_monitor,
+        &to_create,
+        &monitor_map,
+        &ctx.config,
+        hotspot_ctx,
+    );
+    (ctx.rebuild_fn)();
+}
+
+/// Returns a single deduplicated list combining physical-add and zombie
+/// rebuild names. Both go through the same `add_new_docks` creation path —
+/// they only differ in why they're being added.
+fn combine_add_lists(to_add: &[String], zombies: &[String]) -> Vec<String> {
+    let mut combined = to_add.to_vec();
+    for name in zombies {
+        if !combined.contains(name) {
+            combined.push(name.clone());
+        }
+    }
+    combined
 }
 
 /// Returns the output names of dock windows whose layer-shell surface is
@@ -258,21 +267,30 @@ fn zombie_names(
         .collect()
 }
 
-/// Merges zombie names into the to_add/to_remove lists from `compute_monitor_diff`
-/// so reconciliation destroys and re-creates each zombie's window. Dedupes
-/// against existing entries so we don't remove or add a name twice.
-fn merge_zombies_into_diff(
-    to_add: &mut Vec<String>,
-    to_remove: &mut Vec<String>,
+/// Removes dock windows flagged as zombies (surface is None) so they can be
+/// rebuilt. Logs with "rebuild" wording to distinguish this from physical
+/// disconnects handled by `remove_orphaned_docks`.
+fn remove_zombie_docks(
+    per_monitor: &Rc<RefCell<Vec<MonitorDock>>>,
     zombies: &[String],
+    hotspot_ctx: Option<&crate::ui::hotspot::HotspotContext>,
 ) {
     for name in zombies {
-        if !to_remove.contains(name) {
-            to_remove.push(name.clone());
+        if let Some(ctx) = hotspot_ctx {
+            ctx.remove_hotspot_for_output(name);
         }
-        if !to_add.contains(name) {
-            to_add.push(name.clone());
-        }
+        per_monitor.borrow_mut().retain(|dock| {
+            if &dock.output_name == name {
+                log::warn!(
+                    "Rebuilding zombie dock for '{}' (layer-shell surface was destroyed)",
+                    name
+                );
+                dock.win.close();
+                false
+            } else {
+                true
+            }
+        });
     }
 }
 
@@ -283,28 +301,11 @@ fn merge_zombies_into_diff(
 /// checks — no IPC, no allocations of any real cost. Reconciliation is only
 /// triggered when state actually diverges from expectations, so the hot path
 /// runs about as often as real monitor state changes (rare).
-pub fn setup_liveness_tick(
-    app: &gtk4::Application,
-    per_monitor: &Rc<RefCell<Vec<MonitorDock>>>,
-    config: &Rc<DockConfig>,
-    rebuild_fn: &Rc<dyn Fn()>,
-    hotspot_ctx: Option<Rc<crate::ui::hotspot::HotspotContext>>,
-) {
-    let app = app.clone();
-    let per_monitor = Rc::clone(per_monitor);
-    let config = Rc::clone(config);
-    let rebuild_fn = Rc::clone(rebuild_fn);
-
+pub fn setup_liveness_tick(ctx: Rc<ReconcileContext>) {
     glib::timeout_add_local(LIVENESS_TICK_INTERVAL, move || {
-        if needs_reconcile(&per_monitor, &config) {
+        if needs_reconcile(&ctx.per_monitor, &ctx.config) {
             log::info!("Liveness tick detected state drift, reconciling");
-            reconcile_monitors(
-                &app,
-                &per_monitor,
-                &config,
-                &rebuild_fn,
-                hotspot_ctx.as_deref(),
-            );
+            reconcile_monitors(&ctx);
         }
         glib::ControlFlow::Continue
     });
@@ -452,7 +453,7 @@ fn add_new_docks(
 
 #[cfg(test)]
 mod tests {
-    use super::{decide_reconcile, merge_zombies_into_diff, zombie_names};
+    use super::{combine_add_lists, decide_reconcile, zombie_names};
 
     fn names(s: &[&str]) -> Vec<String> {
         s.iter().map(|x| (*x).to_string()).collect()
@@ -684,71 +685,51 @@ mod tests {
         assert!(zombie_names(&[], &[], &names(&["DP-1"])).is_empty());
     }
 
-    // ─── merge_zombies_into_diff: the bridge between diff and zombie handling ──
+    // ─── combine_add_lists: dedup physical adds with zombie rebuilds ───────────
 
     #[test]
-    fn merge_zombies_adds_to_both_lists_when_absent() {
-        let mut to_add: Vec<String> = vec![];
-        let mut to_remove: Vec<String> = vec![];
+    fn combine_add_lists_empty_inputs_produces_empty() {
+        assert!(combine_add_lists(&[], &[]).is_empty());
+    }
+
+    #[test]
+    fn combine_add_lists_only_new_monitors() {
+        let to_add = names(&["DP-1", "HDMI-A-1"]);
+        let zombies: Vec<String> = vec![];
+        assert_eq!(combine_add_lists(&to_add, &zombies), to_add);
+    }
+
+    #[test]
+    fn combine_add_lists_only_zombies() {
+        let to_add: Vec<String> = vec![];
         let zombies = names(&["DP-1"]);
-        merge_zombies_into_diff(&mut to_add, &mut to_remove, &zombies);
-        assert_eq!(to_add, names(&["DP-1"]));
-        assert_eq!(to_remove, names(&["DP-1"]));
+        assert_eq!(combine_add_lists(&to_add, &zombies), names(&["DP-1"]));
     }
 
     #[test]
-    fn merge_zombies_is_noop_when_already_queued() {
-        // Zombie is also in to_add/to_remove from some other path — don't duplicate
-        let mut to_add = names(&["DP-1"]);
-        let mut to_remove = names(&["DP-1"]);
+    fn combine_add_lists_distinct_sets_concatenated() {
+        let to_add = names(&["DP-2"]);
         let zombies = names(&["DP-1"]);
-        merge_zombies_into_diff(&mut to_add, &mut to_remove, &zombies);
-        assert_eq!(to_add, names(&["DP-1"]));
-        assert_eq!(to_remove, names(&["DP-1"]));
+        let combined = combine_add_lists(&to_add, &zombies);
+        assert!(combined.contains(&"DP-1".to_string()));
+        assert!(combined.contains(&"DP-2".to_string()));
+        assert_eq!(combined.len(), 2);
     }
 
     #[test]
-    fn merge_zombies_preserves_existing_entries() {
-        // Existing hotplug-diff entries must not be clobbered
-        let mut to_add = names(&["HDMI-A-1"]);
-        let mut to_remove = names(&["DP-2"]);
+    fn combine_add_lists_deduplicates_overlap() {
+        // Pathological but defensive: if the same name appears in both lists
+        // (e.g. a monitor was simultaneously classified as new and zombie),
+        // we should only create one window.
+        let to_add = names(&["DP-1"]);
         let zombies = names(&["DP-1"]);
-        merge_zombies_into_diff(&mut to_add, &mut to_remove, &zombies);
-        assert!(to_add.contains(&"HDMI-A-1".to_string()));
-        assert!(to_add.contains(&"DP-1".to_string()));
-        assert!(to_remove.contains(&"DP-2".to_string()));
-        assert!(to_remove.contains(&"DP-1".to_string()));
+        assert_eq!(combine_add_lists(&to_add, &zombies), names(&["DP-1"]));
     }
 
     #[test]
-    fn merge_zombies_empty_list_is_noop() {
-        let mut to_add = names(&["HDMI-A-1"]);
-        let mut to_remove = names(&["DP-2"]);
-        merge_zombies_into_diff(&mut to_add, &mut to_remove, &[]);
-        assert_eq!(to_add, names(&["HDMI-A-1"]));
-        assert_eq!(to_remove, names(&["DP-2"]));
-    }
-
-    #[test]
-    fn merge_zombies_deduplicates_repeated_zombies_in_input() {
-        // Defensive: zombies list shouldn't have duplicates in practice,
-        // but if it does, merge should still produce a deduped result
-        let mut to_add: Vec<String> = vec![];
-        let mut to_remove: Vec<String> = vec![];
+    fn combine_add_lists_deduplicates_repeated_zombies() {
+        let to_add: Vec<String> = vec![];
         let zombies = names(&["DP-1", "DP-1"]);
-        merge_zombies_into_diff(&mut to_add, &mut to_remove, &zombies);
-        assert_eq!(to_add, names(&["DP-1"]));
-        assert_eq!(to_remove, names(&["DP-1"]));
-    }
-
-    #[test]
-    fn merge_zombies_mixed_new_and_existing() {
-        // One zombie is already in to_remove but not to_add — half-handled
-        let mut to_add: Vec<String> = vec![];
-        let mut to_remove = names(&["DP-1"]);
-        let zombies = names(&["DP-1", "HDMI-A-1"]);
-        merge_zombies_into_diff(&mut to_add, &mut to_remove, &zombies);
-        assert_eq!(to_add, names(&["DP-1", "HDMI-A-1"]));
-        assert_eq!(to_remove, names(&["DP-1", "HDMI-A-1"]));
+        assert_eq!(combine_add_lists(&to_add, &zombies), names(&["DP-1"]));
     }
 }

--- a/crates/nwg-dock/src/listeners.rs
+++ b/crates/nwg-dock/src/listeners.rs
@@ -17,6 +17,12 @@ use std::time::Duration;
 /// Delay before hiding dock windows after initial present (allows GTK to render).
 const AUTOHIDE_INITIAL_DELAY: Duration = Duration::from_millis(500);
 
+/// Interval for the dock liveness tick — detects missed monitor hotplug events,
+/// zombie layer-shell surfaces (DPMS/lock cycles), and drift between expected
+/// and actual dock windows. In-process pointer checks only in the cold path,
+/// reconciliation only fires when state actually diverges.
+const LIVENESS_TICK_INTERVAL: Duration = Duration::from_secs(2);
+
 /// Sets up an inotify-based pin file watcher that triggers a rebuild
 /// when the pin file is modified (e.g. by the drawer).
 pub fn setup_pin_watcher(pinned_file: &Path, rebuild: &Rc<dyn Fn()>) {
@@ -172,7 +178,8 @@ pub fn setup_monitor_watcher(
 }
 
 /// Reconciles dock windows with current monitor topology.
-/// Creates windows for new monitors, destroys windows for removed monitors.
+/// Creates windows for new monitors, destroys windows for removed monitors,
+/// and rebuilds zombie windows (`surface().is_none()` — DPMS/lock cycles).
 fn reconcile_monitors(
     app: &gtk4::Application,
     per_monitor: &Rc<RefCell<Vec<MonitorDock>>>,
@@ -190,11 +197,23 @@ fn reconcile_monitors(
         .map(|d| d.output_name.clone())
         .collect();
 
-    let (to_add, to_remove) = dock_windows::compute_monitor_diff(&existing_names, &current_names);
+    let (mut to_add, mut to_remove) =
+        dock_windows::compute_monitor_diff(&existing_names, &current_names);
 
     // Always refresh GDK monitor references — a reconnected monitor with the same
     // connector name produces a new gdk::Monitor object, and the old one is stale.
     refresh_monitor_refs(per_monitor, &monitor_map, hotspot_ctx);
+
+    // Detect zombie windows: for monitors present in both sets, check if the
+    // dock's layer-shell surface is still valid. If not, force remove+re-add.
+    let zombies = find_zombie_docks(per_monitor, &current_names);
+    for name in &zombies {
+        log::warn!(
+            "Zombie dock detected for '{}' (surface is None), rebuilding",
+            name
+        );
+    }
+    merge_zombies_into_diff(&mut to_add, &mut to_remove, &zombies);
 
     if to_add.is_empty() && to_remove.is_empty() {
         log::debug!("Monitor topology unchanged after debounce");
@@ -204,6 +223,154 @@ fn reconcile_monitors(
     remove_orphaned_docks(per_monitor, &to_remove, hotspot_ctx);
     add_new_docks(app, per_monitor, &to_add, &monitor_map, config, hotspot_ctx);
     rebuild_fn();
+}
+
+/// Returns the output names of dock windows whose layer-shell surface is
+/// missing (zombie state). A zombie window has an `ApplicationWindow` object
+/// in our `per_monitor` Vec but `surface()` returns None — the compositor
+/// has destroyed the underlying surface and the window is unrecoverable
+/// without being re-created.
+fn find_zombie_docks(
+    per_monitor: &Rc<RefCell<Vec<MonitorDock>>>,
+    present_names: &[String],
+) -> Vec<String> {
+    let docks = per_monitor.borrow();
+    let names: Vec<String> = docks.iter().map(|d| d.output_name.clone()).collect();
+    let has_surface: Vec<bool> = docks.iter().map(|d| d.win.surface().is_some()).collect();
+    drop(docks);
+    zombie_names(&names, &has_surface, present_names)
+}
+
+/// Pure selection logic for `find_zombie_docks`. Given the dock list (names +
+/// per-dock surface validity) and the names of monitors currently known by
+/// GDK, returns the names of docks that are zombies — i.e. their monitor
+/// still exists but their surface is gone.
+fn zombie_names(
+    dock_names: &[String],
+    dock_has_surface: &[bool],
+    present_names: &[String],
+) -> Vec<String> {
+    dock_names
+        .iter()
+        .zip(dock_has_surface.iter())
+        .filter(|(name, has_surface)| !**has_surface && present_names.contains(name))
+        .map(|(name, _)| name.clone())
+        .collect()
+}
+
+/// Merges zombie names into the to_add/to_remove lists from `compute_monitor_diff`
+/// so reconciliation destroys and re-creates each zombie's window. Dedupes
+/// against existing entries so we don't remove or add a name twice.
+fn merge_zombies_into_diff(
+    to_add: &mut Vec<String>,
+    to_remove: &mut Vec<String>,
+    zombies: &[String],
+) {
+    for name in zombies {
+        if !to_remove.contains(name) {
+            to_remove.push(name.clone());
+        }
+        if !to_add.contains(name) {
+            to_add.push(name.clone());
+        }
+    }
+}
+
+/// Starts a periodic liveness tick that catches missed hotplug events and
+/// zombie layer-shell surfaces. Fires every `LIVENESS_TICK_INTERVAL`.
+///
+/// In the cold path (nothing wrong), each tick does only in-process pointer
+/// checks — no IPC, no allocations of any real cost. Reconciliation is only
+/// triggered when state actually diverges from expectations, so the hot path
+/// runs about as often as real monitor state changes (rare).
+pub fn setup_liveness_tick(
+    app: &gtk4::Application,
+    per_monitor: &Rc<RefCell<Vec<MonitorDock>>>,
+    config: &Rc<DockConfig>,
+    rebuild_fn: &Rc<dyn Fn()>,
+    hotspot_ctx: Option<Rc<crate::ui::hotspot::HotspotContext>>,
+) {
+    let app = app.clone();
+    let per_monitor = Rc::clone(per_monitor);
+    let config = Rc::clone(config);
+    let rebuild_fn = Rc::clone(rebuild_fn);
+
+    glib::timeout_add_local(LIVENESS_TICK_INTERVAL, move || {
+        if needs_reconcile(&per_monitor) {
+            log::info!("Liveness tick detected state drift, reconciling");
+            reconcile_monitors(
+                &app,
+                &per_monitor,
+                &config,
+                &rebuild_fn,
+                hotspot_ctx.as_deref(),
+            );
+        }
+        glib::ControlFlow::Continue
+    });
+}
+
+/// Returns true if the dock's per-monitor state diverges from GDK's current
+/// monitor list, or if any existing dock has a zombie surface.
+/// Pure read-only checks — no IPC, no side effects.
+fn needs_reconcile(per_monitor: &Rc<RefCell<Vec<MonitorDock>>>) -> bool {
+    let Some(display) = gtk4::gdk::Display::default() else {
+        return false;
+    };
+    let model = display.monitors();
+
+    // Collect current GDK connector names (stable identifiers)
+    let mut current: Vec<String> = Vec::with_capacity(model.n_items() as usize);
+    for i in 0..model.n_items() {
+        if let Some(item) = model.item(i)
+            && let Ok(mon) = item.downcast::<gtk4::gdk::Monitor>()
+            && let Some(connector) = mon.connector()
+        {
+            current.push(connector.to_string());
+        }
+    }
+
+    let docks = per_monitor.borrow();
+    let dock_names: Vec<String> = docks.iter().map(|d| d.output_name.clone()).collect();
+    let dock_has_surface: Vec<bool> = docks.iter().map(|d| d.win.surface().is_some()).collect();
+    drop(docks);
+
+    decide_reconcile(&current, &dock_names, &dock_has_surface)
+}
+
+/// Pure decision logic for `needs_reconcile`. Testable without GTK —
+/// given the current GDK monitor names and the dock's state (names +
+/// per-dock surface validity), decides whether reconciliation is needed.
+fn decide_reconcile(
+    gdk_names: &[String],
+    dock_names: &[String],
+    dock_has_surface: &[bool],
+) -> bool {
+    // Missing monitor: GDK has a connector we don't have a dock for
+    for name in gdk_names {
+        if !dock_names.contains(name) {
+            log::debug!("Liveness: missing dock for '{}'", name);
+            return true;
+        }
+    }
+
+    // Stale dock: we have a dock for a connector GDK doesn't report anymore
+    for name in dock_names {
+        if !gdk_names.contains(name) {
+            log::debug!("Liveness: stale dock for '{}'", name);
+            return true;
+        }
+    }
+
+    // Zombie surface: dock object exists but layer-shell surface is gone
+    for (name, has_surface) in dock_names.iter().zip(dock_has_surface.iter()) {
+        if !has_surface {
+            log::debug!("Liveness: zombie surface for '{}'", name);
+            return true;
+        }
+    }
+
+    false
 }
 
 /// Refreshes GDK monitor references on existing dock and hotspot windows.
@@ -270,5 +437,274 @@ fn add_new_docks(
             ctx.add_hotspot_for_dock(&dock);
         }
         per_monitor.borrow_mut().push(dock);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decide_reconcile, merge_zombies_into_diff, zombie_names};
+
+    fn names(s: &[&str]) -> Vec<String> {
+        s.iter().map(|x| (*x).to_string()).collect()
+    }
+
+    // ─── decide_reconcile: steady-state and basic cases ────────────────────────
+
+    #[test]
+    fn decide_reconcile_steady_state_returns_false() {
+        let gdk = names(&["DP-1", "HDMI-A-1"]);
+        let docks = names(&["DP-1", "HDMI-A-1"]);
+        let surfaces = vec![true, true];
+        assert!(!decide_reconcile(&gdk, &docks, &surfaces));
+    }
+
+    #[test]
+    fn decide_reconcile_empty_state_stable() {
+        // No monitors, no docks — nothing to reconcile
+        assert!(!decide_reconcile(&[], &[], &[]));
+    }
+
+    #[test]
+    fn decide_reconcile_single_monitor_stable() {
+        let gdk = names(&["DP-1"]);
+        let docks = names(&["DP-1"]);
+        let surfaces = vec![true];
+        assert!(!decide_reconcile(&gdk, &docks, &surfaces));
+    }
+
+    #[test]
+    fn decide_reconcile_three_monitors_all_healthy() {
+        let gdk = names(&["DP-1", "DP-2", "HDMI-A-1"]);
+        let docks = names(&["DP-1", "DP-2", "HDMI-A-1"]);
+        let surfaces = vec![true, true, true];
+        assert!(!decide_reconcile(&gdk, &docks, &surfaces));
+    }
+
+    // ─── decide_reconcile: missing dock (hotplug arrival) ──────────────────────
+
+    #[test]
+    fn decide_reconcile_detects_missing_dock_for_new_monitor() {
+        let gdk = names(&["DP-1", "HDMI-A-1"]);
+        let docks = names(&["DP-1"]);
+        let surfaces = vec![true];
+        assert!(decide_reconcile(&gdk, &docks, &surfaces));
+    }
+
+    #[test]
+    fn decide_reconcile_detects_all_monitors_missing_at_startup_race() {
+        // Worst case: GDK knows monitors but we haven't built any docks yet.
+        // Should still flag reconcile — otherwise we'd be permanently empty.
+        let gdk = names(&["DP-1"]);
+        assert!(decide_reconcile(&gdk, &[], &[]));
+    }
+
+    #[test]
+    fn decide_reconcile_detects_third_monitor_missing() {
+        let gdk = names(&["DP-1", "DP-2", "HDMI-A-1"]);
+        let docks = names(&["DP-1", "DP-2"]);
+        let surfaces = vec![true, true];
+        assert!(decide_reconcile(&gdk, &docks, &surfaces));
+    }
+
+    // ─── decide_reconcile: stale dock (unplug missed) ──────────────────────────
+
+    #[test]
+    fn decide_reconcile_detects_stale_dock_after_unplug() {
+        let gdk = names(&["DP-1"]);
+        let docks = names(&["DP-1", "HDMI-A-1"]);
+        let surfaces = vec![true, true];
+        assert!(decide_reconcile(&gdk, &docks, &surfaces));
+    }
+
+    #[test]
+    fn decide_reconcile_detects_all_monitors_gone() {
+        // Extreme case: every monitor unplugged but our docks linger
+        let docks = names(&["DP-1", "HDMI-A-1"]);
+        let surfaces = vec![true, true];
+        assert!(decide_reconcile(&[], &docks, &surfaces));
+    }
+
+    // ─── decide_reconcile: zombie surfaces (DPMS/lock) ─────────────────────────
+
+    #[test]
+    fn decide_reconcile_detects_zombie_surface() {
+        let gdk = names(&["DP-1"]);
+        let docks = names(&["DP-1"]);
+        let surfaces = vec![false];
+        assert!(decide_reconcile(&gdk, &docks, &surfaces));
+    }
+
+    #[test]
+    fn decide_reconcile_detects_zombie_among_healthy() {
+        let gdk = names(&["DP-1", "HDMI-A-1"]);
+        let docks = names(&["DP-1", "HDMI-A-1"]);
+        let surfaces = vec![true, false];
+        assert!(decide_reconcile(&gdk, &docks, &surfaces));
+    }
+
+    #[test]
+    fn decide_reconcile_detects_all_zombies() {
+        // Nightmare case: every dock went zombie (full DPMS wipe)
+        let gdk = names(&["DP-1", "HDMI-A-1"]);
+        let docks = names(&["DP-1", "HDMI-A-1"]);
+        let surfaces = vec![false, false];
+        assert!(decide_reconcile(&gdk, &docks, &surfaces));
+    }
+
+    // ─── decide_reconcile: combined divergences ────────────────────────────────
+
+    #[test]
+    fn decide_reconcile_missing_and_stale_together() {
+        // DP-1 removed, HDMI-A-1 added — full swap
+        let gdk = names(&["HDMI-A-1"]);
+        let docks = names(&["DP-1"]);
+        let surfaces = vec![true];
+        assert!(decide_reconcile(&gdk, &docks, &surfaces));
+    }
+
+    #[test]
+    fn decide_reconcile_missing_and_zombie_together() {
+        // A monitor was added, and an existing one's surface died
+        let gdk = names(&["DP-1", "HDMI-A-1"]);
+        let docks = names(&["DP-1"]);
+        let surfaces = vec![false];
+        assert!(decide_reconcile(&gdk, &docks, &surfaces));
+    }
+
+    // ─── decide_reconcile: ordering and duplicates ─────────────────────────────
+
+    #[test]
+    fn decide_reconcile_handles_reordered_names() {
+        let gdk = names(&["HDMI-A-1", "DP-1"]);
+        let docks = names(&["DP-1", "HDMI-A-1"]);
+        let surfaces = vec![true, true];
+        assert!(!decide_reconcile(&gdk, &docks, &surfaces));
+    }
+
+    #[test]
+    fn decide_reconcile_idempotent_on_repeat_calls() {
+        // Same input → same result, no hidden state
+        let gdk = names(&["DP-1"]);
+        let docks = names(&["DP-1"]);
+        let surfaces = vec![true];
+        let first = decide_reconcile(&gdk, &docks, &surfaces);
+        let second = decide_reconcile(&gdk, &docks, &surfaces);
+        assert_eq!(first, second);
+        assert!(!first);
+    }
+
+    // ─── zombie_names: pure selection of broken docks ──────────────────────────
+
+    #[test]
+    fn zombie_names_empty_when_all_healthy() {
+        let docks = names(&["DP-1", "HDMI-A-1"]);
+        let surfaces = vec![true, true];
+        let present = names(&["DP-1", "HDMI-A-1"]);
+        assert!(zombie_names(&docks, &surfaces, &present).is_empty());
+    }
+
+    #[test]
+    fn zombie_names_identifies_single_zombie() {
+        let docks = names(&["DP-1", "HDMI-A-1"]);
+        let surfaces = vec![true, false];
+        let present = names(&["DP-1", "HDMI-A-1"]);
+        assert_eq!(
+            zombie_names(&docks, &surfaces, &present),
+            names(&["HDMI-A-1"])
+        );
+    }
+
+    #[test]
+    fn zombie_names_identifies_multiple_zombies() {
+        let docks = names(&["DP-1", "DP-2", "HDMI-A-1"]);
+        let surfaces = vec![false, true, false];
+        let present = names(&["DP-1", "DP-2", "HDMI-A-1"]);
+        assert_eq!(
+            zombie_names(&docks, &surfaces, &present),
+            names(&["DP-1", "HDMI-A-1"])
+        );
+    }
+
+    #[test]
+    fn zombie_names_excludes_docks_for_removed_monitors() {
+        // If a monitor is physically gone, its dock isn't a "zombie" — it's
+        // stale and will be removed via the normal diff path. Don't double-count.
+        let docks = names(&["DP-1", "HDMI-A-1"]);
+        let surfaces = vec![true, false];
+        let present = names(&["DP-1"]); // HDMI-A-1 is physically gone
+        assert!(zombie_names(&docks, &surfaces, &present).is_empty());
+    }
+
+    #[test]
+    fn zombie_names_empty_docks_produces_empty() {
+        assert!(zombie_names(&[], &[], &names(&["DP-1"])).is_empty());
+    }
+
+    // ─── merge_zombies_into_diff: the bridge between diff and zombie handling ──
+
+    #[test]
+    fn merge_zombies_adds_to_both_lists_when_absent() {
+        let mut to_add: Vec<String> = vec![];
+        let mut to_remove: Vec<String> = vec![];
+        let zombies = names(&["DP-1"]);
+        merge_zombies_into_diff(&mut to_add, &mut to_remove, &zombies);
+        assert_eq!(to_add, names(&["DP-1"]));
+        assert_eq!(to_remove, names(&["DP-1"]));
+    }
+
+    #[test]
+    fn merge_zombies_is_noop_when_already_queued() {
+        // Zombie is also in to_add/to_remove from some other path — don't duplicate
+        let mut to_add = names(&["DP-1"]);
+        let mut to_remove = names(&["DP-1"]);
+        let zombies = names(&["DP-1"]);
+        merge_zombies_into_diff(&mut to_add, &mut to_remove, &zombies);
+        assert_eq!(to_add, names(&["DP-1"]));
+        assert_eq!(to_remove, names(&["DP-1"]));
+    }
+
+    #[test]
+    fn merge_zombies_preserves_existing_entries() {
+        // Existing hotplug-diff entries must not be clobbered
+        let mut to_add = names(&["HDMI-A-1"]);
+        let mut to_remove = names(&["DP-2"]);
+        let zombies = names(&["DP-1"]);
+        merge_zombies_into_diff(&mut to_add, &mut to_remove, &zombies);
+        assert!(to_add.contains(&"HDMI-A-1".to_string()));
+        assert!(to_add.contains(&"DP-1".to_string()));
+        assert!(to_remove.contains(&"DP-2".to_string()));
+        assert!(to_remove.contains(&"DP-1".to_string()));
+    }
+
+    #[test]
+    fn merge_zombies_empty_list_is_noop() {
+        let mut to_add = names(&["HDMI-A-1"]);
+        let mut to_remove = names(&["DP-2"]);
+        merge_zombies_into_diff(&mut to_add, &mut to_remove, &[]);
+        assert_eq!(to_add, names(&["HDMI-A-1"]));
+        assert_eq!(to_remove, names(&["DP-2"]));
+    }
+
+    #[test]
+    fn merge_zombies_deduplicates_repeated_zombies_in_input() {
+        // Defensive: zombies list shouldn't have duplicates in practice,
+        // but if it does, merge should still produce a deduped result
+        let mut to_add: Vec<String> = vec![];
+        let mut to_remove: Vec<String> = vec![];
+        let zombies = names(&["DP-1", "DP-1"]);
+        merge_zombies_into_diff(&mut to_add, &mut to_remove, &zombies);
+        assert_eq!(to_add, names(&["DP-1"]));
+        assert_eq!(to_remove, names(&["DP-1"]));
+    }
+
+    #[test]
+    fn merge_zombies_mixed_new_and_existing() {
+        // One zombie is already in to_remove but not to_add — half-handled
+        let mut to_add: Vec<String> = vec![];
+        let mut to_remove = names(&["DP-1"]);
+        let zombies = names(&["DP-1", "HDMI-A-1"]);
+        merge_zombies_into_diff(&mut to_add, &mut to_remove, &zombies);
+        assert_eq!(to_add, names(&["DP-1", "HDMI-A-1"]));
+        assert_eq!(to_remove, names(&["DP-1", "HDMI-A-1"]));
     }
 }

--- a/crates/nwg-dock/src/main.rs
+++ b/crates/nwg-dock/src/main.rs
@@ -149,7 +149,8 @@ fn activate_dock(
     );
     listeners::setup_pin_watcher(pinned_file, &rebuild);
     listeners::setup_signal_poller(app, &per_monitor, sig_rx);
-    listeners::setup_monitor_watcher(app, &per_monitor, config, &rebuild, hotspot_ctx);
+    listeners::setup_monitor_watcher(app, &per_monitor, config, &rebuild, hotspot_ctx.clone());
+    listeners::setup_liveness_tick(app, &per_monitor, config, &rebuild, hotspot_ctx);
 }
 
 /// Auto-detect launcher: hide button if command not found on PATH.

--- a/crates/nwg-dock/src/main.rs
+++ b/crates/nwg-dock/src/main.rs
@@ -149,8 +149,16 @@ fn activate_dock(
     );
     listeners::setup_pin_watcher(pinned_file, &rebuild);
     listeners::setup_signal_poller(app, &per_monitor, sig_rx);
-    listeners::setup_monitor_watcher(app, &per_monitor, config, &rebuild, hotspot_ctx.clone());
-    listeners::setup_liveness_tick(app, &per_monitor, config, &rebuild, hotspot_ctx);
+
+    let reconcile_ctx = Rc::new(listeners::ReconcileContext {
+        app: app.clone(),
+        per_monitor: Rc::clone(&per_monitor),
+        config: Rc::clone(config),
+        rebuild_fn: Rc::clone(&rebuild),
+        hotspot_ctx,
+    });
+    listeners::setup_monitor_watcher(Rc::clone(&reconcile_ctx));
+    listeners::setup_liveness_tick(reconcile_ctx);
 }
 
 /// Auto-detect launcher: hide button if command not found on PATH.

--- a/crates/nwg-dock/src/monitor.rs
+++ b/crates/nwg-dock/src/monitor.rs
@@ -26,17 +26,37 @@ pub fn map_outputs_by_connector() -> HashMap<String, gdk::Monitor> {
 }
 
 /// Resolves which monitors to show the dock on, based on the -o flag.
-/// Returns (output_name, gdk_monitor) pairs.
+/// Returns (output_name, gdk_monitor) pairs. Logs a warning if `-o` targets
+/// an unknown output. Use `resolve_monitors_quiet` for hot paths (liveness
+/// tick) where repeated warnings would spam the log.
 pub fn resolve_monitors(config: &crate::config::DockConfig) -> Vec<(String, gdk::Monitor)> {
+    resolve_monitors_inner(config, true)
+}
+
+/// Same as `resolve_monitors` but silent on unknown-output — used by the
+/// liveness tick where we'd otherwise log the same warning every 2 seconds
+/// if the user's `--output` target is mistyped or temporarily unavailable.
+/// The startup/reconcile path still uses the loud variant so the warning
+/// surfaces once per real topology change.
+pub fn resolve_monitors_quiet(config: &crate::config::DockConfig) -> Vec<(String, gdk::Monitor)> {
+    resolve_monitors_inner(config, false)
+}
+
+fn resolve_monitors_inner(
+    config: &crate::config::DockConfig,
+    log_unknown_output: bool,
+) -> Vec<(String, gdk::Monitor)> {
     let output_map = map_outputs_by_connector();
     if !config.output.is_empty() {
         if let Some(mon) = output_map.get(&config.output) {
             vec![(config.output.clone(), mon.clone())]
         } else {
-            log::warn!(
-                "Target output '{}' not found, using all monitors",
-                config.output
-            );
+            if log_unknown_output {
+                log::warn!(
+                    "Target output '{}' not found, using all monitors",
+                    config.output
+                );
+            }
             output_map.into_iter().collect()
         }
     } else {


### PR DESCRIPTION
## Summary

Three bugs — **one root cause**. Fixing all three with a single mechanism.

| Issue | Symptom |
|-------|---------|
| **#53** | Plug in second monitor → dock doesn't appear on it. Restart required. |
| **#45** | DPMS off/on cycle → dock process alive, but windows unresponsive. Signals don't recover. |
| **#61** | Overnight idle/lock sequence → same as #45, reproducible daily. |

## Root cause

The dock's per-monitor state can diverge from reality without us knowing:

1. **GDK's `items-changed` signal is flaky** — on some hotplug events and on DPMS cycles it simply doesn't fire (verified empirically in prior investigation).
2. **Compositor can destroy layer-shell surfaces silently** — the `ApplicationWindow` object stays alive but `win.surface()` returns `None`. Nothing in the code except `cursor_poller.rs` was checking for this before.

Both cases leave us with zombie or missing dock windows and no way to recover short of a manual restart.

## Fix

Two defenses, sharing one mechanism:

### 1. Periodic liveness tick (every 2s)
Added `setup_liveness_tick` that compares GDK's current monitor list against our `per_monitor` Vec and checks each dock's `win.surface().is_some()`. If anything diverges, it triggers the existing `reconcile_monitors` path.

### 2. Zombie-aware reconciliation
`reconcile_monitors` now detects zombie docks (monitor still present, surface gone) and merges them into the `to_add`/`to_remove` lists so they get destroyed and recreated — instead of the previous behavior of skipping them as "unchanged".

## Performance

Every 2 seconds, in the cold path (nothing wrong):

- 1 GDK monitor list iteration (1–3 items) — pointer fetch, no IPC
- `win.surface()` check per dock — pointer fetch
- String compare of monitor names
- Total: tens of microseconds

The "hot path" (reconcile needed) only runs when state actually changes — so in steady state, zero reconciles. Compare to the existing cursor poller that runs IPC-heavy work every 200ms; the liveness tick is strictly cheaper.

## Testability

Extracted three pure helpers so the decision logic is unit-testable without GTK:

- `decide_reconcile(gdk_names, dock_names, dock_has_surface) -> bool`
- `zombie_names(dock_names, dock_has_surface, present_names) -> Vec<String>`
- `merge_zombies_into_diff(&mut to_add, &mut to_remove, &zombies)`

## Test plan

- [x] **27 new unit tests** — 274 total, all passing
  - Steady state / no-op cases (7 tests)
  - Missing dock / hotplug detection (3 tests)
  - Stale dock / unplug detection (2 tests)
  - Zombie surface detection (3 tests)
  - Combined divergences (missing + stale, missing + zombie) (2 tests)
  - Ordering / idempotency (2 tests)
  - `zombie_names` selection correctness (5 tests)
  - `merge_zombies_into_diff` dedup + preservation (6 tests)
- [x] Clippy zero warnings
- [x] SonarQube zero issues on changed files
- [ ] Manual smoke test: plug in second monitor → dock appears within 2s
- [ ] Manual smoke test: `hyprctl dispatch dpms off && sleep 5 && hyprctl dispatch dpms on` → dock recovers without restart
- [ ] Manual soak test: leave running overnight through the full idle/lock sequence

## Closes

- Fixes #45
- Fixes #53
- Fixes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Periodic liveness checks to assess dock health and auto-trigger reconciliation.
  * Unified watcher and liveness handling so monitor changes are handled more consistently.
  * Option to suppress noisy "unknown output" warnings when resolving monitors.

* **Bug Fixes**
  * Detects and removes stale "zombie" docks with missing surfaces and recreates them.
  * More robust reconciliation to reduce intermittent missing or stale dock entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->