### PR TITLE
Fix accumulating empty dock slots after unpin/close (#62)

### DIFF
--- a/crates/nwg-dock-common/src/config/flags.rs
+++ b/crates/nwg-dock-common/src/config/flags.rs
@@ -20,28 +20,34 @@ pub fn normalize_legacy_flags(
             result.push(arg);
             continue;
         }
-        // Map -v to --version (Go compatibility for nwg-shell config utility)
-        if arg == "-v" {
-            result.push("--version".to_string());
-            continue;
+        match rewrite_arg(&arg, legacy_flags) {
+            Some(rewritten) => result.push(rewritten),
+            None => result.push(arg),
         }
-        // Convert -flag or -flag=value to --flag or --flag=value
-        if let Some(name) = arg.strip_prefix('-')
-            && !name.starts_with('-')
-        {
-            if let Some((flag, value)) = name.split_once('=') {
-                if legacy_flags.contains(&flag) {
-                    result.push(format!("--{}={}", flag, value));
-                    continue;
-                }
-            } else if legacy_flags.contains(&name) {
-                result.push(format!("--{}", name));
-                continue;
-            }
-        }
-        result.push(arg);
     }
     result
+}
+
+/// Rewrites a single argument if it's a recognized Go-style legacy flag,
+/// returning `None` to leave it unchanged otherwise. Splitting this out
+/// keeps the main loop shallow enough to stay under the cognitive-
+/// complexity budget (sonar rust:S3776).
+fn rewrite_arg(arg: &str, legacy_flags: &'static [&'static str]) -> Option<String> {
+    // Map -v to --version (Go compatibility for nwg-shell config utility)
+    if arg == "-v" {
+        return Some("--version".to_string());
+    }
+    let name = arg.strip_prefix('-')?;
+    if name.starts_with('-') {
+        return None;
+    }
+    if let Some((flag, value)) = name.split_once('=') {
+        legacy_flags
+            .contains(&flag)
+            .then(|| format!("--{}={}", flag, value))
+    } else {
+        legacy_flags.contains(&name).then(|| format!("--{}", name))
+    }
 }
 
 #[cfg(test)]

--- a/crates/nwg-dock-common/src/hyprland/events.rs
+++ b/crates/nwg-dock-common/src/hyprland/events.rs
@@ -6,7 +6,15 @@ use std::os::unix::net::UnixStream;
 /// Events emitted by the Hyprland event stream.
 #[derive(Debug, Clone)]
 pub enum HyprEvent {
-    /// Active window changed. Contains the window address.
+    /// A client changed in a way that may affect the visible client list:
+    /// focus moved, a window opened/closed, or a window moved across
+    /// workspaces. Carries the address from the originating event so
+    /// downstream dedup against the last-seen address still works.
+    ///
+    /// Folded together so the dock has a single "rebuild may be needed"
+    /// signal — `needs_rebuild` does the actual class-list diff and
+    /// short-circuits if nothing changed. This mirrors what the Sway
+    /// backend already does (`new`/`close`/`focus` → ActiveWindowChanged).
     ActiveWindowV2(String),
     /// Monitor added or removed.
     MonitorChanged,
@@ -78,6 +86,15 @@ impl EventStream {
 fn parse_event(line: &str) -> HyprEvent {
     if let Some(addr) = line.strip_prefix("activewindowv2>>") {
         HyprEvent::ActiveWindowV2(addr.trim().to_string())
+    } else if let Some(rest) = line
+        .strip_prefix("openwindow>>")
+        .or_else(|| line.strip_prefix("closewindow>>"))
+        .or_else(|| line.strip_prefix("movewindowv2>>"))
+        .or_else(|| line.strip_prefix("movewindow>>"))
+    {
+        // First comma-delimited field is the window address for all four events.
+        let addr = rest.split(',').next().unwrap_or("").trim().to_string();
+        HyprEvent::ActiveWindowV2(addr)
     } else if line.starts_with("monitoraddedv2>>") || line.starts_with("monitorremoved>>") {
         HyprEvent::MonitorChanged
     } else {
@@ -116,5 +133,43 @@ mod tests {
     #[test]
     fn parse_other_event() {
         assert!(matches!(parse_event("workspace>>2"), HyprEvent::Other(_)));
+    }
+
+    /// Regression: closing a non-focused window must propagate as a window-change
+    /// signal, not get swallowed as `Other`. Without this the dock keeps showing
+    /// a button for an app that is no longer running.
+    #[test]
+    fn parse_close_window_yields_address() {
+        match parse_event("closewindow>>0xdeadbeef") {
+            HyprEvent::ActiveWindowV2(addr) => assert_eq!(addr, "0xdeadbeef"),
+            other => panic!("expected ActiveWindowV2, got {:?}", other),
+        }
+    }
+
+    /// Companion to the close case — a new window must trigger the same signal.
+    #[test]
+    fn parse_open_window_extracts_first_field() {
+        match parse_event("openwindow>>0xabc123,1,Alacritty,Terminal") {
+            HyprEvent::ActiveWindowV2(addr) => assert_eq!(addr, "0xabc123"),
+            other => panic!("expected ActiveWindowV2, got {:?}", other),
+        }
+    }
+
+    /// movewindow events change which workspace a client is on, which can
+    /// affect which clients should appear in the dock under workspace filters.
+    #[test]
+    fn parse_move_window_extracts_address() {
+        match parse_event("movewindow>>0xfeed,2") {
+            HyprEvent::ActiveWindowV2(addr) => assert_eq!(addr, "0xfeed"),
+            other => panic!("expected ActiveWindowV2, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_movewindow_v2_extracts_address() {
+        match parse_event("movewindowv2>>0xfeed,3,workspace-3") {
+            HyprEvent::ActiveWindowV2(addr) => assert_eq!(addr, "0xfeed"),
+            other => panic!("expected ActiveWindowV2, got {:?}", other),
+        }
     }
 }

--- a/crates/nwg-dock/src/dock_windows.rs
+++ b/crates/nwg-dock/src/dock_windows.rs
@@ -2,7 +2,7 @@ use crate::config::DockConfig;
 use crate::ui;
 use gtk4::prelude::*;
 use gtk4_layer_shell::LayerShell;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 /// Per-monitor dock window state used during rebuilds.
@@ -12,6 +12,10 @@ pub struct MonitorDock {
     pub alignment_box: gtk4::Box,
     pub current_main_box: Rc<RefCell<Option<gtk4::Box>>>,
     pub win: gtk4::ApplicationWindow,
+    /// Item count from the previous rebuild — used to detect content
+    /// shrinkage so we only force a layer-shell surface reset when
+    /// actually needed (issue #62 fix without per-rebuild flicker).
+    pub prev_item_count: Cell<usize>,
 }
 
 /// Creates a dock window for each monitor and returns the per-monitor state.
@@ -55,6 +59,7 @@ pub fn create_single_dock_window(
         alignment_box,
         current_main_box: Rc::new(RefCell::new(None)),
         win,
+        prev_item_count: Cell::new(0),
     }
 }
 

--- a/crates/nwg-dock/src/rebuild.rs
+++ b/crates/nwg-dock/src/rebuild.rs
@@ -77,43 +77,7 @@ pub fn create_rebuild_fn(
                 };
 
                 for dock in per_monitor.borrow().iter() {
-                    // Defense-in-depth: remove ALL children from
-                    // alignment_box, not just the tracked main_box. If a
-                    // ghost widget ever slipped through (older bug or
-                    // future regression), this purges it.
-                    while let Some(child) = dock.alignment_box.first_child() {
-                        dock.alignment_box.remove(&child);
-                    }
-                    dock.current_main_box.borrow_mut().take();
-
-                    let new_box = ui::dock_box::build(&dock.alignment_box, &ctx, &dock.win);
-                    let new_count = count_children(&new_box);
-                    *dock.current_main_box.borrow_mut() = Some(new_box);
-
-                    // Layer-shell surfaces don't shrink on their own when
-                    // content shrinks — GTK keeps a high-water-mark
-                    // allocation and `queue_resize` / `present` aren't enough
-                    // to invalidate it. The only reliable way is a hide/show
-                    // cycle, which tears the surface down and re-creates it
-                    // at the new natural size.
-                    //
-                    // Doing that on every rebuild causes a visible flicker,
-                    // so we only force the cycle when the item count actually
-                    // dropped — i.e. when the surface is now larger than it
-                    // needs to be (issue #62). Growing or steady-state
-                    // rebuilds don't need it; the surface naturally accepts a
-                    // larger natural-size request. Autohide users never see
-                    // this bug because the hover-driven hide/show does the
-                    // same thing for free.
-                    let prev = dock.prev_item_count.get();
-                    if dock.win.is_visible() && new_count < prev {
-                        let win = dock.win.clone();
-                        gtk4::glib::idle_add_local_once(move || {
-                            win.set_visible(false);
-                            win.set_visible(true);
-                        });
-                    }
-                    dock.prev_item_count.set(new_count);
+                    rebuild_one_dock(dock, &ctx);
                 }
 
                 // If another rebuild was requested during this iteration
@@ -133,10 +97,49 @@ pub fn create_rebuild_fn(
     rebuild_fn
 }
 
+/// Rebuilds the content of a single monitor's dock window.
+///
+/// Clears the alignment_box, builds a fresh main_box via dock_box::build,
+/// and triggers a layer-shell surface reset (hide/show cycle) if the item
+/// count dropped compared to the previous rebuild — see the outer loop
+/// comment for why shrink-only, and issue #62 for the underlying cause.
+fn rebuild_one_dock(dock: &MonitorDock, ctx: &DockContext) {
+    // Defense-in-depth: remove ALL children from alignment_box, not just
+    // the tracked main_box. If a ghost widget ever slipped through (older
+    // bug or future regression), this purges it.
+    while let Some(child) = dock.alignment_box.first_child() {
+        dock.alignment_box.remove(&child);
+    }
+    dock.current_main_box.borrow_mut().take();
+
+    let new_box = ui::dock_box::build(&dock.alignment_box, ctx, &dock.win);
+    let new_count = count_children(&new_box);
+    *dock.current_main_box.borrow_mut() = Some(new_box);
+
+    let prev = dock.prev_item_count.get();
+    if dock.win.is_visible() && new_count < prev {
+        schedule_surface_reset(&dock.win);
+    }
+    dock.prev_item_count.set(new_count);
+}
+
+/// Defers a hide/show cycle via an idle callback. The hide/show tears
+/// down the layer-shell surface and re-creates it at the new natural
+/// size, which is the only reliable way to shrink a layer-shell
+/// allocation in GTK4 — `queue_resize` and `present` both leave the
+/// surface at its high-water-mark width.
+fn schedule_surface_reset(win: &gtk4::ApplicationWindow) {
+    let win = win.clone();
+    gtk4::glib::idle_add_local_once(move || {
+        win.set_visible(false);
+        win.set_visible(true);
+    });
+}
+
 /// Counts the immediate children of a Box. Used to compare new vs previous
 /// rebuild item counts so we can detect content shrinkage and trigger the
 /// layer-shell surface reset only when actually needed (see issue #62 fix
-/// in the rebuild loop above).
+/// in `rebuild_one_dock`).
 fn count_children(parent: &gtk4::Box) -> usize {
     let mut n = 0;
     let mut child = parent.first_child();

--- a/crates/nwg-dock/src/rebuild.rs
+++ b/crates/nwg-dock/src/rebuild.rs
@@ -5,13 +5,20 @@ use crate::state::DockState;
 use crate::ui;
 use gtk4::prelude::*;
 use nwg_dock_common::compositor::Compositor;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::{Rc, Weak};
 
 /// Creates the rebuild function that rebuilds dock content on all monitors.
 ///
 /// Uses `Weak` for the self-reference to avoid an Rc cycle. Buttons inside
 /// the dock can trigger a rebuild via the `DockContext.rebuild` callback.
+///
+/// Reentrancy is guarded: `dock_box::build()` calls into glycin for icon
+/// loading, which uses D-Bus and pumps the GTK main loop. That can let
+/// another timer/event fire and call rebuild_fn while we're mid-build,
+/// which previously left ghost widgets in `alignment_box`. The guard
+/// turns recursive calls into a "pending" flag and re-runs once the
+/// current rebuild finishes.
 pub fn create_rebuild_fn(
     per_monitor: &Rc<RefCell<Vec<MonitorDock>>>,
     config: &Rc<DockConfig>,
@@ -31,34 +38,111 @@ pub fn create_rebuild_fn(
     type RebuildHolder = Rc<RefCell<Weak<dyn Fn()>>>;
     let holder: RebuildHolder = Rc::new(RefCell::new(Weak::<Box<dyn Fn()>>::new()));
 
+    // Reentrancy guards. `running` is set while a rebuild is in flight.
+    // `pending` is set if rebuild_fn is called while one is already running,
+    // and triggers a re-run once the current rebuild completes.
+    let running = Rc::new(Cell::new(false));
+    let pending = Rc::new(Cell::new(false));
+
     let rebuild_fn = {
         let holder = Rc::clone(&holder);
+        let running = Rc::clone(&running);
+        let pending = Rc::clone(&pending);
 
         Rc::new(move || {
-            // Upgrade the weak self-reference for passing to buttons
-            let rebuild_ref: Rc<dyn Fn()> =
-                holder.borrow().upgrade().unwrap_or_else(|| Rc::new(|| {}));
-
-            let ctx = DockContext {
-                config: Rc::clone(&config),
-                state: Rc::clone(&state),
-                data_home: Rc::clone(&data_home),
-                pinned_file: Rc::clone(&pinned_file),
-                rebuild: rebuild_ref,
-                compositor: Rc::clone(&compositor),
-            };
-
-            for dock in per_monitor.borrow().iter() {
-                if let Some(old) = dock.current_main_box.borrow_mut().take() {
-                    dock.alignment_box.remove(&old);
-                }
-                let new_box = ui::dock_box::build(&dock.alignment_box, &ctx, &dock.win);
-                *dock.current_main_box.borrow_mut() = Some(new_box);
+            if running.get() {
+                // Mid-flight rebuild detected (likely glycin pumping the
+                // main loop). Don't recurse — flag the request and the
+                // outer loop below will pick it up.
+                pending.set(true);
+                return;
             }
+
+            running.set(true);
+
+            loop {
+                pending.set(false);
+
+                // Upgrade the weak self-reference for passing to buttons
+                let rebuild_ref: Rc<dyn Fn()> =
+                    holder.borrow().upgrade().unwrap_or_else(|| Rc::new(|| {}));
+
+                let ctx = DockContext {
+                    config: Rc::clone(&config),
+                    state: Rc::clone(&state),
+                    data_home: Rc::clone(&data_home),
+                    pinned_file: Rc::clone(&pinned_file),
+                    rebuild: rebuild_ref,
+                    compositor: Rc::clone(&compositor),
+                };
+
+                for dock in per_monitor.borrow().iter() {
+                    // Defense-in-depth: remove ALL children from
+                    // alignment_box, not just the tracked main_box. If a
+                    // ghost widget ever slipped through (older bug or
+                    // future regression), this purges it.
+                    while let Some(child) = dock.alignment_box.first_child() {
+                        dock.alignment_box.remove(&child);
+                    }
+                    dock.current_main_box.borrow_mut().take();
+
+                    let new_box = ui::dock_box::build(&dock.alignment_box, &ctx, &dock.win);
+                    let new_count = count_children(&new_box);
+                    *dock.current_main_box.borrow_mut() = Some(new_box);
+
+                    // Layer-shell surfaces don't shrink on their own when
+                    // content shrinks — GTK keeps a high-water-mark
+                    // allocation and `queue_resize` / `present` aren't enough
+                    // to invalidate it. The only reliable way is a hide/show
+                    // cycle, which tears the surface down and re-creates it
+                    // at the new natural size.
+                    //
+                    // Doing that on every rebuild causes a visible flicker,
+                    // so we only force the cycle when the item count actually
+                    // dropped — i.e. when the surface is now larger than it
+                    // needs to be (issue #62). Growing or steady-state
+                    // rebuilds don't need it; the surface naturally accepts a
+                    // larger natural-size request. Autohide users never see
+                    // this bug because the hover-driven hide/show does the
+                    // same thing for free.
+                    let prev = dock.prev_item_count.get();
+                    if dock.win.is_visible() && new_count < prev {
+                        let win = dock.win.clone();
+                        gtk4::glib::idle_add_local_once(move || {
+                            win.set_visible(false);
+                            win.set_visible(true);
+                        });
+                    }
+                    dock.prev_item_count.set(new_count);
+                }
+
+                // If another rebuild was requested during this iteration
+                // (glycin pumped the loop, a timer fired, etc.), do it
+                // again with the latest state. Otherwise we're done.
+                if !pending.get() {
+                    break;
+                }
+            }
+
+            running.set(false);
         })
     };
 
     // Store a Weak reference — no cycle
     *holder.borrow_mut() = Rc::downgrade(&rebuild_fn) as Weak<dyn Fn()>;
     rebuild_fn
+}
+
+/// Counts the immediate children of a Box. Used to compare new vs previous
+/// rebuild item counts so we can detect content shrinkage and trigger the
+/// layer-shell surface reset only when actually needed (see issue #62 fix
+/// in the rebuild loop above).
+fn count_children(parent: &gtk4::Box) -> usize {
+    let mut n = 0;
+    let mut child = parent.first_child();
+    while let Some(w) = child {
+        n += 1;
+        child = w.next_sibling();
+    }
+    n
 }

--- a/crates/nwg-dock/src/ui/buttons.rs
+++ b/crates/nwg-dock/src/ui/buttons.rs
@@ -109,14 +109,8 @@ pub fn pinned_button(app_id: &str, index: usize, ctx: &DockContext) -> gtk4::Box
     let app_dirs = ctx.state.borrow().app_dirs.clone();
 
     let button = gtk4::Button::new();
-    let image = icons::create_image(app_id, img_size, &app_dirs).unwrap_or_else(|| {
-        let path = ctx
-            .data_home
-            .join("nwg-dock-hyprland/images/icon-missing.svg");
-        icons::pixbuf_from_file(&path, img_size, img_size)
-            .map(|pb| gtk4::Image::from_pixbuf(Some(&pb)))
-            .unwrap_or_default()
-    });
+    let image = icons::create_image(app_id, img_size, &app_dirs)
+        .unwrap_or_else(|| gtk4::Image::from_icon_name("image-missing"));
     image.set_pixel_size(img_size);
     button.set_child(Some(&image));
     button.add_css_class("dock-button");
@@ -182,14 +176,8 @@ pub fn task_button(client: &WmClient, instances: &[WmClient], ctx: &DockContext)
     let app_dirs = ctx.state.borrow().app_dirs.clone();
 
     let button = gtk4::Button::new();
-    let image = icons::create_image(&client.class, img_size, &app_dirs).unwrap_or_else(|| {
-        let path = ctx
-            .data_home
-            .join("nwg-dock-hyprland/images/icon-missing.svg");
-        icons::pixbuf_from_file(&path, img_size, img_size)
-            .map(|pb| gtk4::Image::from_pixbuf(Some(&pb)))
-            .unwrap_or_default()
-    });
+    let image = icons::create_image(&client.class, img_size, &app_dirs)
+        .unwrap_or_else(|| gtk4::Image::from_icon_name("image-missing"));
     image.set_pixel_size(img_size);
     button.set_child(Some(&image));
     button.add_css_class("dock-button");

--- a/crates/nwg-dock/src/ui/buttons.rs
+++ b/crates/nwg-dock/src/ui/buttons.rs
@@ -109,8 +109,7 @@ pub fn pinned_button(app_id: &str, index: usize, ctx: &DockContext) -> gtk4::Box
     let app_dirs = ctx.state.borrow().app_dirs.clone();
 
     let button = gtk4::Button::new();
-    let image = icons::create_image(app_id, img_size, &app_dirs)
-        .unwrap_or_else(|| gtk4::Image::from_icon_name("image-missing"));
+    let image = icons::create_image(app_id, img_size, &app_dirs).unwrap_or_else(missing_icon);
     image.set_pixel_size(img_size);
     button.set_child(Some(&image));
     button.add_css_class("dock-button");
@@ -176,8 +175,8 @@ pub fn task_button(client: &WmClient, instances: &[WmClient], ctx: &DockContext)
     let app_dirs = ctx.state.borrow().app_dirs.clone();
 
     let button = gtk4::Button::new();
-    let image = icons::create_image(&client.class, img_size, &app_dirs)
-        .unwrap_or_else(|| gtk4::Image::from_icon_name("image-missing"));
+    let image =
+        icons::create_image(&client.class, img_size, &app_dirs).unwrap_or_else(missing_icon);
     image.set_pixel_size(img_size);
     button.set_child(Some(&image));
     button.add_css_class("dock-button");
@@ -299,4 +298,12 @@ pub fn launcher_button(ctx: &DockContext, win: &gtk4::ApplicationWindow) -> Opti
         ctx.config.position,
         ctx.config.is_vertical(),
     ))
+}
+
+/// Placeholder image used when an app's icon can't be resolved. Goes through
+/// GTK4's icon theme rather than gdk-pixbuf so it renders even on systems
+/// where the gdk-pixbuf SVG loader module is missing (modern librsvg).
+/// Centralized so both pinned and task buttons stay in sync.
+fn missing_icon() -> gtk4::Image {
+    gtk4::Image::from_icon_name("image-missing")
 }


### PR DESCRIPTION
Closes #62.

## Summary
- **Hyprland event coverage**: `closewindow` / `openwindow` / `movewindow[v2]` were silently dropped by the parser, so the dock never rebuilt after a background window closed. Folded them into the existing `ActiveWindowV2` signal so the standard `needs_rebuild` diff picks them up — matching what the Sway backend already does for `new`/`close`.
- **Layer-shell shrink fix**: when content shrinks (unpin, app close), GTK's layer-shell surface keeps its high-water-mark width. `queue_resize` and `present` don't invalidate it; only a hide/show cycle re-acks the new natural size. We now track per-dock item count and force a hide/show cycle only when the count actually drops, so steady-state and growing rebuilds still don't flicker. Autohide users were never hit because the hover-driven cycle does this for free.
- **Rebuild reentrancy guard**: `dock_box::build` calls into glycin, which pumps the GTK main loop and can re-enter `rebuild_fn`. Added running/pending Cells so reentrant calls flag a re-run instead of recursing, plus a defensive sweep that purges all `alignment_box` children each rebuild (not just the tracked main_box).
- **Icon-missing fallback**: replaced the silent `Image::default()` blank widget with `Image::from_icon_name("image-missing")`, which uses GTK4's theme system and always renders something visible even when the gdk-pixbuf SVG loader is missing.

## Test plan
- [x] `cargo test --workspace` — 281 unit tests pass (incl. 4 new event-parser regression tests)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo deny check` — advisories/bans/licenses/sources OK
- [x] SonarQube quality gate OK (0 new violations)
- [x] Smoke tested locally on Hyprland, both autohide config and the original non-autohide repro from #62
- [x] Reviewer to smoke test against their own dock config

## Follow-up
Filed #67 to expand the headless-Sway integration test suite so this class of regression is caught automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dock refresh stability when handling rapid window changes.
  * Enhanced recognition of window events (open, close, workspace move) for better dock synchronization.
  * Better fallback behavior for missing application icons.

* **Improvements**
  * Rebuild logic gains reentrancy protection and more robust per-monitor rebuild handling, including surface reset when needed.
  * Per-monitor tracking improved to reduce unnecessary rebuilds.

* **Tests**
  * Added unit tests covering window-event address extraction.

* **Chores**
  * Internal flag-normalization refactor (no behavioral change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->