### PR TITLE
Migrate drawer math eval from meval to exmex (#64, #28)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "exmex"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "114e4321fcb0242ffe3092e29a7a41c11fc119f1fa8e61cd21b72a68dd004aaa"
+dependencies = [
+ "lazy_static",
+ "num-traits",
+ "regex",
+ "smallvec",
+]
+
+[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,12 +247,6 @@ dependencies = [
  "memoffset",
  "rustc_version",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fsevent-sys"
@@ -726,6 +732,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,16 +774,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "meval"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79496a5651c8d57cd033c5add8ca7ee4e3d5f7587a4777484640d9cb60392d9"
-dependencies = [
- "fnv",
- "nom",
-]
-
-[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,12 +796,6 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
-
-[[package]]
-name = "nom"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
 
 [[package]]
 name = "notify"
@@ -826,6 +822,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
  "bitflags 2.11.1",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -870,10 +875,10 @@ dependencies = [
  "anyhow",
  "clap",
  "env_logger",
+ "exmex",
  "gtk4",
  "gtk4-layer-shell",
  "log",
- "meval",
  "nix",
  "notify",
  "nwg-dock-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,10 @@ nix = { version = "0.31", features = ["signal", "process", "fs"] }
 # Shell-aware command splitting (POSIX quoting rules)
 shell-words = "1"
 
-# Math expression evaluation (search bar calculator)
-meval = "0.2"
+# Math expression evaluation (search bar calculator).
+# Migrated off `meval` because its nom 1.2.4 transitive dep emits a
+# future-incompat warning on every build and is unmaintained since 2018.
+exmex = "0.20"
 
 # XDG directory resolution
 dirs = "6"

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ Intentional differences from the original Go nwg-dock-hyprland and nwg-drawer:
 - **Per-monitor dock windows** — the Go dock creates one window; the Rust dock creates a separate window per monitor for better multi-monitor support.
 - **Smart rebuild** — the Go dock force-rebuilds on every active window event; the Rust dock only rebuilds when the client class list or active window actually changes (more efficient).
 - **Compositor abstraction** — the Go versions are Hyprland-only; this Rust port supports Hyprland and Sway via a trait-based compositor abstraction with auto-detection.
-- **Math evaluation** — the Go drawer uses the `expr` library for arbitrary expression evaluation; the Rust port uses a custom arithmetic parser (safer, covers the common use case).
+- **Math evaluation** — the Go drawer uses the `expr` library for arbitrary expression evaluation; the Rust port uses the `exmex` crate with a small custom operator factory that adds `pi` (alongside `π`), `%` modulo, and base-10 `log`. Scoped to pure arithmetic (no variables) so random search queries don't accidentally evaluate.
 - **Drag-to-reorder** — new feature not in the Go dock: drag pinned icons to rearrange, drag off to unpin.
 - **CLI flag naming** — multi-word flags standardized to kebab-case (e.g., `--nocats` → `--no-cats`, `--pbsize` → `--pb-size`). Multi-char Go short forms (`-hd`, `-iw`, `-is`) not available in clap (single-char only); use the long forms instead.
 - **Fuzzy class matching** — compositor classes with hyphens vs spaces (e.g., desktop file `github-desktop` vs compositor class `github desktop`) are matched automatically for correct icon display and process grouping.

--- a/crates/nwg-drawer/Cargo.toml
+++ b/crates/nwg-drawer/Cargo.toml
@@ -21,4 +21,4 @@ log = { workspace = true }
 env_logger = { workspace = true }
 notify = { workspace = true }
 nix = { workspace = true }
-meval = { workspace = true }
+exmex = { workspace = true }

--- a/crates/nwg-drawer/src/ui/math.rs
+++ b/crates/nwg-drawer/src/ui/math.rs
@@ -1,3 +1,4 @@
+use exmex::{BinOp, Express, FlatEx, FloatOpsFactory, MakeOperators, Operator};
 use gtk4::prelude::*;
 
 /// Result of attempting to evaluate a math expression.
@@ -12,16 +13,68 @@ pub enum MathResult {
     NotMath,
 }
 
-/// Evaluates a math expression using the meval crate.
+/// Operator factory extending exmex's default float operators with the
+/// user-facing behaviors meval provided so the migration (#64) is
+/// transparent to people typing math in the search bar:
+///
+/// - `pi` as an alias for `π` — exmex ships `π` only, but humans type `pi`.
+/// - `%` as a binary modulo operator — exmex documents `%` as a custom
+///   operator example but doesn't register it by default.
+/// - `log` redefined to base-10 — exmex's default `log` is the natural
+///   logarithm (same as `ln`), whereas calculators and meval treat `log`
+///   as log-base-10. `ln` stays available for natural log.
+///
+/// `%` priority matches exmex's `/` (prio 3), which is higher than `*`
+/// (prio 2). Within a single priority class exmex resolves
+/// right-associatively, so picking `/`'s priority keeps `10 % 3 * 2`
+/// evaluating as `(10 % 3) * 2 = 2` rather than `10 % (3 * 2) = 4`.
+#[derive(Clone, Debug)]
+struct DrawerOpsFactory;
+impl MakeOperators<f64> for DrawerOpsFactory {
+    fn make<'a>() -> Vec<Operator<'a, f64>> {
+        let mut ops: Vec<Operator<'a, f64>> = FloatOpsFactory::<f64>::make()
+            .into_iter()
+            .filter(|op| op.repr() != "log")
+            .collect();
+        ops.push(Operator::make_unary("log", |a| a.log10()));
+        ops.push(Operator::make_constant("pi", std::f64::consts::PI));
+        ops.push(Operator::make_bin(
+            "%",
+            BinOp {
+                apply: |a, b| a % b,
+                prio: 3,
+                is_commutative: false,
+            },
+        ));
+        ops
+    }
+}
+
+/// Evaluates a math expression using the exmex crate.
 /// Supports: +, -, *, /, ^, %, parentheses, decimals,
-/// functions (sin, cos, sqrt, abs, ln, log, etc.),
-/// and constants (pi, e).
+/// functions (sin, cos, tan, sqrt, abs, ln, log, floor, ceil, signum, cbrt, tanh, ...),
+/// and constants (pi, π, e).
+///
+/// Migrated from meval in #64 to eliminate the nom 1.2.4
+/// future-incompat warning. exmex returns a single `ExError` for both
+/// parse and runtime failures; we squash all Err results to `NotMath`
+/// so partially-typed expressions don't show a red error inline. NaN
+/// and infinity are mapped to user-facing error messages identically
+/// to the old behavior.
 pub fn eval_expression(expr: &str) -> MathResult {
     let trimmed = expr.trim();
     if trimmed.is_empty() {
         return MathResult::NotMath;
     }
-    match meval::eval_str(trimmed) {
+    let parsed = match FlatEx::<f64, DrawerOpsFactory>::parse(trimmed) {
+        Ok(p) => p,
+        Err(_) => return MathResult::NotMath,
+    };
+    // Pure arithmetic only — expressions with free variables (unknown
+    // identifiers that aren't our registered constants) are treated as
+    // "not math". The empty binding slice makes `exmex::Express::eval`
+    // return Err for any unresolved variable, which matches the intent.
+    match parsed.eval(&[]) {
         Ok(val) if val.is_nan() => MathResult::Error("undefined".to_string()),
         Ok(val) if val.is_infinite() => MathResult::Error("overflow".to_string()),
         Ok(val) => MathResult::Value(val),
@@ -368,5 +421,71 @@ mod tests {
         // Test negative exponent with trailing zero: 1e-5 < 1e-4, above zero-snap
         let result = format_result(1e-5);
         assert!(result.contains("e-5"), "exponent corrupted: {}", result);
+    }
+
+    // ─── Regression tests for the meval → exmex migration (#64) ──────────
+    //
+    // These pin down behaviors that exmex doesn't provide out of the box
+    // but that meval did, so our custom `DrawerOpsFactory` must continue
+    // to cover them. If someone ever trims the factory these will fail
+    // loudly before users see the regression.
+
+    #[test]
+    fn pi_and_pi_unicode_both_resolve() {
+        // meval accepted `pi`; exmex ships only the Unicode `π` by default.
+        // Our factory adds `pi` as an alias, so both must work and agree.
+        let via_ascii = eval_val("pi");
+        let via_unicode = eval_val("π");
+        assert!((via_ascii - std::f64::consts::PI).abs() < 1e-10);
+        assert!((via_unicode - std::f64::consts::PI).abs() < 1e-10);
+        assert_eq!(via_ascii, via_unicode);
+    }
+
+    #[test]
+    fn modulo_in_basic_and_compound_expressions() {
+        // exmex doesn't register `%` by default. Our factory adds it with
+        // priority 2, matching `*` and `/` so precedence behaves as expected.
+        assert_eq!(eval_val("10 % 3"), 1.0);
+        assert_eq!(eval_val("17 % 5"), 2.0);
+        // Precedence sanity: `%` and `*` share priority → left-to-right
+        assert_eq!(eval_val("10 % 3 * 2"), 2.0);
+        // `%` after `+` → `+` should happen first since `+` is lower prio
+        assert_eq!(eval_val("7 + 10 % 3"), 8.0);
+    }
+
+    #[test]
+    fn unbound_identifier_is_not_math() {
+        // exmex parses app names as free variables — we must reject them
+        // so typing "firefox" in the drawer doesn't show a math result row.
+        assert!(matches!(eval_expression("xyz"), MathResult::NotMath));
+        assert!(matches!(eval_expression("foo + 1"), MathResult::NotMath));
+    }
+
+    #[test]
+    fn whitespace_trimming() {
+        // Leading/trailing/internal whitespace must all parse the same as
+        // the bare expression — meval was lenient here and users rely on it.
+        assert_eq!(eval_val("  2 + 2  "), 4.0);
+        assert_eq!(eval_val("2+2"), 4.0);
+        assert_eq!(eval_val("2 + 2"), 4.0);
+    }
+
+    #[test]
+    fn sin_pi_is_effectively_zero() {
+        // Classic FP smoke test: sin(pi) is ~1.2e-16, not exactly 0.
+        // format_result snaps that to "0" for display — verify the raw
+        // eval is at least tiny so the display path works.
+        let val = eval_val("sin(pi)");
+        assert!(val.abs() < 1e-10, "sin(pi) = {} should be ~0", val);
+        assert_eq!(format_result(val), "0");
+    }
+
+    #[test]
+    fn common_math_functions_available() {
+        // Round-up of functions the issue listed as non-negotiable.
+        assert!((eval_val("cos(0)") - 1.0).abs() < 1e-10);
+        assert!((eval_val("tan(0)") - 0.0).abs() < 1e-10);
+        assert!((eval_val("ln(e)") - 1.0).abs() < 1e-10);
+        assert!((eval_val("log(100)") - 2.0).abs() < 1e-10);
     }
 }

--- a/crates/nwg-drawer/src/ui/math.rs
+++ b/crates/nwg-drawer/src/ui/math.rs
@@ -25,9 +25,9 @@ pub enum MathResult {
 ///   as log-base-10. `ln` stays available for natural log.
 ///
 /// `%` priority matches exmex's `/` (prio 3), which is higher than `*`
-/// (prio 2). Within a single priority class exmex resolves
-/// right-associatively, so picking `/`'s priority keeps `10 % 3 * 2`
-/// evaluating as `(10 % 3) * 2 = 2` rather than `10 % (3 * 2) = 4`.
+/// (prio 2), so `10 % 3 * 2` evaluates as `(10 % 3) * 2 = 2`. Chained
+/// with `/` at the same priority, exmex evaluates left-to-right:
+/// `19 % 5 / 2 = (19 % 5) / 2 = 2`.
 #[derive(Clone, Debug)]
 struct DrawerOpsFactory;
 impl MakeOperators<f64> for DrawerOpsFactory {
@@ -443,13 +443,15 @@ mod tests {
 
     #[test]
     fn modulo_in_basic_and_compound_expressions() {
-        // exmex doesn't register `%` by default. Our factory adds it with
-        // priority 2, matching `*` and `/` so precedence behaves as expected.
+        // exmex doesn't register `%` by default. Our factory adds it at
+        // priority 3, matching `/` and above `*` (prio 2).
         assert_eq!(eval_val("10 % 3"), 1.0);
         assert_eq!(eval_val("17 % 5"), 2.0);
-        // Precedence sanity: `%` and `*` share priority → left-to-right
+        // `%` (prio 3) binds tighter than `*` (prio 2) → `(10 % 3) * 2`
         assert_eq!(eval_val("10 % 3 * 2"), 2.0);
-        // `%` after `+` → `+` should happen first since `+` is lower prio
+        // Same-priority chaining with `/` → left-to-right: `(19 % 5) / 2`
+        assert_eq!(eval_val("19 % 5 / 2"), 2.0);
+        // `%` after `+` → `+` should happen second since `+` is lower prio
         assert_eq!(eval_val("7 + 10 % 3"), 8.0);
     }
 


### PR DESCRIPTION
Closes #64. Closes #28.

## Summary
- Swap `meval 0.2` → `exmex 0.20` in the workspace. Kills the `nom v1.2.4` future-incompat warning permanently — the unmaintained transitive dep is gone.
- Port the one caller (`crates/nwg-drawer/src/ui/math.rs`) to `FlatEx` with a small `DrawerOpsFactory` that preserves meval's user-facing behaviors exmex doesn't ship:
  - `pi` as an alias for `π`
  - `%` binary modulo at priority 3 (keeps `10 % 3 * 2 = 2` — exmex resolves same-priority right-to-left and its `*` is priority 2)
  - `log` rebound to base-10 (exmex's default `log` is natural log; calculators and meval treat `log` as log10)
- Free identifiers map to `NotMath` so typing app names in the search bar doesn't surface a math row.
- Add 6 regression tests covering each migration-specific behavior so any future trim of the ops factory fails loudly.
- README's "Math evaluation" deviation note updated to describe the actual current setup (was claiming a custom parser we never had).

## Test plan
- [x] `cargo test --workspace` — 287 unit tests pass (26 in `ui::math`, up from 20; 6 new regressions cover `pi` alias, `%` precedence, log10, free-identifier rejection, whitespace, `sin(pi)` display)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo deny check` — advisories / bans / licenses / sources OK
- [x] `cargo build --release` no longer emits the `nom v1.2.4` future-incompat warning
- [x] SonarQube quality gate OK (0 new violations)
- [x] Smoke tested locally — drawer math eval working as expected
- [ ] Reviewer to confirm against their daily drawer use

## Behavioral parity checklist (from #64)
- [x] `2+2`, `sqrt(16)`, `sin(pi)` — value results
- [x] `10/0` — "division by zero" maps to `overflow` (infinity) error
- [x] `sqrt(-1)` — `undefined` (NaN) error
- [x] `2^10` — value result; `2^1024` — `overflow` error
- [x] `pi`, `π`, `e` — constants
- [x] `2+`, `(3*`, `sqrt(` — `NotMath` (incomplete while typing)
- [x] `  2 + 2  ` — whitespace trimming
- [x] `10 % 3`, `10 % 3 * 2` — modulo behavior matches meval
- [x] `log(100) = 2` — base-10 log preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for mathematical constants pi/π, modulo (%) operator, and base‑10 log in inline math evaluation.

* **Bug Fixes**
  * Improved parsing and error handling: unbound identifiers are treated as non-math; NaN and infinity map to clearer "undefined"/"overflow" results; whitespace handling more forgiving.

* **Documentation**
  * Updated documentation to list supported functions/constants and behaviors.

* **Tests**
  * Added regression tests covering constants, modulo precedence, chaining, and common functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->