### PR TITLE
Multi-monitor close-on-click for notification panel, DND menu, and drawer (#55)

### DIFF
--- a/crates/nwg-dock-common/src/layer_shell.rs
+++ b/crates/nwg-dock-common/src/layer_shell.rs
@@ -1,0 +1,77 @@
+//! Shared layer-shell helpers used by drawer, notifications panel, and DND menu.
+//!
+//! A layer-shell surface only covers the output it's pinned to, so any UI
+//! element that wants "click anywhere on any monitor closes me" needs one
+//! catcher surface per monitor (issue #55). This module centralizes that
+//! pattern so multiple crates don't drift in their backdrop construction.
+
+use gtk4::prelude::*;
+use gtk4_layer_shell::LayerShell;
+
+/// Configures a single full-screen transparent layer-shell window pinned to
+/// `monitor`. Anchors all four edges, overlay layer, no exclusive zone, no
+/// keyboard input. Caller is responsible for adding any CSS class that
+/// gives the window a non-zero background opacity — without that, some
+/// compositors won't deliver pointer events to it.
+pub fn setup_fullscreen_backdrop(
+    win: &gtk4::ApplicationWindow,
+    namespace: &str,
+    monitor: &gtk4::gdk::Monitor,
+) {
+    win.init_layer_shell();
+    win.set_namespace(Some(namespace));
+    win.set_layer(gtk4_layer_shell::Layer::Overlay);
+    win.set_exclusive_zone(-1);
+    win.set_keyboard_mode(gtk4_layer_shell::KeyboardMode::None);
+    win.set_monitor(Some(monitor));
+    win.set_anchor(gtk4_layer_shell::Edge::Top, true);
+    win.set_anchor(gtk4_layer_shell::Edge::Right, true);
+    win.set_anchor(gtk4_layer_shell::Edge::Bottom, true);
+    win.set_anchor(gtk4_layer_shell::Edge::Left, true);
+}
+
+/// Creates one full-screen transparent backdrop window per connected monitor,
+/// each tagged with `css_class` so the caller's stylesheet can give it the
+/// minimum opacity needed for pointer-event delivery.
+///
+/// `exclude_connector` filters out a single monitor by its GDK connector
+/// name (e.g. `"DP-1"`). Callers that already render their own full-screen
+/// surface on a particular monitor should pass that monitor's connector
+/// here — otherwise the backdrop on the same monitor would race with the
+/// caller's surface for click delivery (drawer use-case, issue #55).
+/// Pass `None` to cover every monitor.
+///
+/// Returns an empty Vec if GDK reports no display (rare; usually a headless
+/// or early-startup transient). Callers should treat the result as the full
+/// backdrop set and toggle them all together.
+pub fn create_fullscreen_backdrops(
+    app: &gtk4::Application,
+    namespace: &str,
+    css_class: &str,
+    exclude_connector: Option<&str>,
+) -> Vec<gtk4::ApplicationWindow> {
+    let Some(display) = gtk4::gdk::Display::default() else {
+        log::warn!("No default GDK display — backdrops disabled");
+        return Vec::new();
+    };
+    let monitors_model = display.monitors();
+    let mut backdrops = Vec::with_capacity(monitors_model.n_items() as usize);
+    for i in 0..monitors_model.n_items() {
+        let Some(item) = monitors_model.item(i) else {
+            continue;
+        };
+        let Ok(monitor) = item.downcast::<gtk4::gdk::Monitor>() else {
+            continue;
+        };
+        if let Some(skip) = exclude_connector
+            && monitor.connector().is_some_and(|c| c == skip)
+        {
+            continue;
+        }
+        let win = gtk4::ApplicationWindow::new(app);
+        win.add_css_class(css_class);
+        setup_fullscreen_backdrop(&win, namespace, &monitor);
+        backdrops.push(win);
+    }
+    backdrops
+}

--- a/crates/nwg-dock-common/src/lib.rs
+++ b/crates/nwg-dock-common/src/lib.rs
@@ -4,6 +4,7 @@ pub mod desktop;
 pub mod error;
 pub mod hyprland;
 pub mod launch;
+pub mod layer_shell;
 pub mod pinning;
 pub mod process;
 pub mod signals;

--- a/crates/nwg-drawer/src/assets/drawer.css
+++ b/crates/nwg-drawer/src/assets/drawer.css
@@ -3,6 +3,20 @@ window {
     color: #e8e8e8;
 }
 
+/* Multi-monitor click-catcher backdrop. One of these is created per
+ * non-drawer monitor (issue #55); clicking any closes the drawer.
+ * The slight black tint matches the macOS Launchpad behavior of
+ * dimming the entire desktop while the launcher is open, and gives
+ * the user a visual cue that "drawer is active" across all monitors.
+ *
+ * Note: pointer events only reach this surface when the drawer is
+ * launched with `-k` (OnDemand keyboard mode). With Exclusive
+ * keyboard (the default) Hyprland routes all input to the drawer's
+ * own surface and clicks on other monitors are dropped. */
+window.drawer-backdrop {
+    background-color: rgba(0, 0, 0, 0.15);
+}
+
 /* Search entry — large, rounded, centered */
 .drawer-search {
     font-size: 18px;

--- a/crates/nwg-drawer/src/main.rs
+++ b/crates/nwg-drawer/src/main.rs
@@ -174,6 +174,45 @@ fn activate_drawer(
         })
     };
 
+    // Multi-monitor click-catcher backdrops. The drawer is a layer-shell
+    // surface pinned to a single output, so clicks on other monitors
+    // never reach it and the existing focus-loss + active-window-poll
+    // close paths sometimes miss them (issue #55). One backdrop per
+    // *other* monitor — the drawer's own monitor is excluded so the
+    // backdrop doesn't race the drawer for click delivery there.
+    let drawer_monitor_name = drawer_monitor_connector(&config, compositor, &target_monitor);
+    let backdrops = nwg_dock_common::layer_shell::create_fullscreen_backdrops(
+        app,
+        "nwg-drawer-backdrop",
+        "drawer-backdrop",
+        drawer_monitor_name.as_deref(),
+    );
+    for backdrop in &backdrops {
+        let click = gtk4::GestureClick::new();
+        let on_launch_bd = Rc::clone(&on_launch);
+        click.connect_released(move |gesture, _, _, _| {
+            gesture.set_state(gtk4::EventSequenceState::Claimed);
+            on_launch_bd();
+        });
+        backdrop.add_controller(click);
+        backdrop.present();
+        backdrop.set_visible(false);
+    }
+    // Sync backdrop visibility with the drawer window. Using
+    // `connect_visible_notify` means every code path that toggles the
+    // drawer's visibility (signal poller, focus-loss, escape, close
+    // button, right-click on background) automatically toggles the
+    // backdrops too — no need to thread the Vec through every site.
+    {
+        let backdrops_sync = backdrops.clone();
+        win.connect_visible_notify(move |w| {
+            let visible = w.is_visible();
+            for b in &backdrops_sync {
+                b.set_visible(visible);
+            }
+        });
+    }
+
     // Pinned items (above scroll, fixed — never scrolls out of view)
     let pinned_box = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
     pinned_box.set_halign(gtk4::Align::Center);
@@ -325,6 +364,39 @@ fn load_preferred_apps(state: &mut DrawerState) {
         log::info!("Found {} custom file associations", pa.len());
         state.preferred_apps = pa;
     }
+}
+
+/// Returns the connector name (e.g. "DP-1") of the monitor the drawer
+/// will appear on, used to exclude that monitor from the click-catcher
+/// backdrop set.
+///
+/// Resolution order:
+/// 1. The GDK monitor returned by `resolve_target_monitor` (set when
+///    the user passed `--output`).
+/// 2. The compositor's currently-focused monitor — this is where
+///    Hyprland places a layer-shell surface that didn't pin an output.
+///
+/// Returns `None` if neither resolves; callers cover all monitors and
+/// accept that the drawer's monitor will get a no-op backdrop racing
+/// with its own surface (the existing right-click-to-close fallback
+/// still works on the drawer itself).
+fn drawer_monitor_connector(
+    config: &DrawerConfig,
+    compositor: &Rc<dyn nwg_dock_common::compositor::Compositor>,
+    target_monitor: &Option<gtk4::gdk::Monitor>,
+) -> Option<String> {
+    if let Some(mon) = target_monitor {
+        return mon.connector().map(|c| c.to_string());
+    }
+    if !config.output.is_empty() {
+        return Some(config.output.clone());
+    }
+    compositor
+        .list_monitors()
+        .ok()?
+        .into_iter()
+        .find(|m| m.focused)
+        .map(|m| m.name)
 }
 
 fn resolve_target_monitor(

--- a/crates/nwg-drawer/src/main.rs
+++ b/crates/nwg-drawer/src/main.rs
@@ -180,34 +180,40 @@ fn activate_drawer(
     // close paths sometimes miss them (issue #55). One backdrop per
     // *other* monitor — the drawer's own monitor is excluded so the
     // backdrop doesn't race the drawer for click delivery there.
-    let drawer_monitor_name = drawer_monitor_connector(&config, compositor, &target_monitor);
-    let backdrops = nwg_dock_common::layer_shell::create_fullscreen_backdrops(
-        app,
-        "nwg-drawer-backdrop",
-        "drawer-backdrop",
-        drawer_monitor_name.as_deref(),
-    );
-    for backdrop in &backdrops {
-        let click = gtk4::GestureClick::new();
-        let on_launch_bd = Rc::clone(&on_launch);
-        click.connect_released(move |gesture, _, _, _| {
-            gesture.set_state(gtk4::EventSequenceState::Claimed);
-            on_launch_bd();
-        });
-        backdrop.add_controller(click);
-        backdrop.present();
-        backdrop.set_visible(false);
-    }
-    // Sync backdrop visibility with the drawer window. Using
-    // `connect_visible_notify` means every code path that toggles the
-    // drawer's visibility (signal poller, focus-loss, escape, close
-    // button, right-click on background) automatically toggles the
-    // backdrops too — no need to thread the Vec through every site.
-    {
-        let backdrops_sync = backdrops.clone();
+    //
+    // Only create backdrops in OnDemand keyboard mode. In Exclusive
+    // mode (the default) Hyprland drops pointer events to other
+    // layer-shell surfaces regardless of opacity — visible backdrops
+    // that never receive clicks would be worse UX than no backdrops
+    // at all (a dimmed desktop with no way to dismiss it).
+    if config.keyboard_on_demand {
+        let drawer_monitor_name = drawer_monitor_connector(&config, compositor, &target_monitor);
+        let backdrops = nwg_dock_common::layer_shell::create_fullscreen_backdrops(
+            app,
+            "nwg-drawer-backdrop",
+            "drawer-backdrop",
+            drawer_monitor_name.as_deref(),
+        );
+        for backdrop in &backdrops {
+            let click = gtk4::GestureClick::new();
+            let on_launch_bd = Rc::clone(&on_launch);
+            click.connect_released(move |gesture, _, _, _| {
+                gesture.set_state(gtk4::EventSequenceState::Claimed);
+                on_launch_bd();
+            });
+            backdrop.add_controller(click);
+            backdrop.present();
+            backdrop.set_visible(false);
+        }
+        // Sync backdrop visibility with the drawer window. Using
+        // `connect_visible_notify` means every code path that toggles
+        // the drawer's visibility (signal poller, focus-loss, escape,
+        // close button, right-click on background) automatically
+        // toggles the backdrops too — no need to thread the Vec
+        // through every site.
         win.connect_visible_notify(move |w| {
             let visible = w.is_visible();
-            for b in &backdrops_sync {
+            for b in &backdrops {
                 b.set_visible(visible);
             }
         });
@@ -385,8 +391,16 @@ fn drawer_monitor_connector(
     compositor: &Rc<dyn nwg_dock_common::compositor::Compositor>,
     target_monitor: &Option<gtk4::gdk::Monitor>,
 ) -> Option<String> {
-    if let Some(mon) = target_monitor {
-        return mon.connector().map(|c| c.to_string());
+    // Let-guard so the target_monitor branch only returns when a connector
+    // name is actually available. On backends where GDK omits connector
+    // metadata we fall through to the `--output` flag and then to the
+    // compositor's focused-monitor answer, rather than giving up and
+    // creating a backdrop that races the drawer for clicks on the same
+    // output (CodeRabbit catch on #71).
+    if let Some(mon) = target_monitor
+        && let Some(connector) = mon.connector().map(|c| c.to_string())
+    {
+        return Some(connector);
     }
     if !config.output.is_empty() {
         return Some(config.output.clone());

--- a/crates/nwg-drawer/src/main.rs
+++ b/crates/nwg-drawer/src/main.rs
@@ -407,6 +407,7 @@ fn drawer_monitor_connector(
     }
     compositor
         .list_monitors()
+        .map_err(|e| log::debug!("list_monitors failed while resolving drawer monitor: {e}"))
         .ok()?
         .into_iter()
         .find(|m| m.focused)

--- a/crates/nwg-notifications/src/ui/dnd_menu.rs
+++ b/crates/nwg-notifications/src/ui/dnd_menu.rs
@@ -29,8 +29,12 @@ impl DndMenu {
         on_state_change: Rc<dyn Fn()>,
     ) -> Self {
         // One transparent backdrop per connected monitor for click-outside-to-close
-        let backdrops =
-            super::window::create_fullscreen_backdrops(app, "mac-notification-dnd-backdrop");
+        let backdrops = nwg_dock_common::layer_shell::create_fullscreen_backdrops(
+            app,
+            "mac-notification-dnd-backdrop",
+            "dnd-menu-backdrop",
+            None,
+        );
 
         let win = gtk4::ApplicationWindow::new(app);
         win.add_css_class("dnd-menu-window");

--- a/crates/nwg-notifications/src/ui/dnd_menu.rs
+++ b/crates/nwg-notifications/src/ui/dnd_menu.rs
@@ -14,7 +14,10 @@ const TIMED_OPTIONS: &[(u64, &str)] = &[
 /// A small popup menu for DND options, triggered by right-clicking the waybar bell.
 pub struct DndMenu {
     win: gtk4::ApplicationWindow,
-    backdrop: gtk4::ApplicationWindow,
+    /// One transparent backdrop layer-shell surface per monitor. Same
+    /// rationale as `NotificationPanel::backdrops` — a single layer-shell
+    /// surface can't cover more than one output (issue #55).
+    backdrops: Vec<gtk4::ApplicationWindow>,
     state: Rc<RefCell<NotificationState>>,
     on_state_change: Rc<dyn Fn()>,
 }
@@ -25,34 +28,39 @@ impl DndMenu {
         state: &Rc<RefCell<NotificationState>>,
         on_state_change: Rc<dyn Fn()>,
     ) -> Self {
-        // Transparent backdrop for click-outside-to-close
-        let backdrop = gtk4::ApplicationWindow::new(app);
-        backdrop.add_css_class("dnd-menu-backdrop");
-        setup_backdrop_window(&backdrop);
+        // One transparent backdrop per connected monitor for click-outside-to-close
+        let backdrops =
+            super::window::create_fullscreen_backdrops(app, "mac-notification-dnd-backdrop");
 
         let win = gtk4::ApplicationWindow::new(app);
         win.add_css_class("dnd-menu-window");
         setup_menu_window(&win);
 
-        // Backdrop click → close menu
-        let click = gtk4::GestureClick::new();
-        let win_bd = win.clone();
-        let backdrop_bd = backdrop.clone();
-        click.connect_released(move |gesture, _, _, _| {
-            gesture.set_state(gtk4::EventSequenceState::Claimed);
-            win_bd.set_visible(false);
-            backdrop_bd.set_visible(false);
-        });
-        backdrop.add_controller(click);
+        // Backdrop click (on any monitor) → close menu
+        for backdrop in &backdrops {
+            let click = gtk4::GestureClick::new();
+            let win_bd = win.clone();
+            let backdrops_bd = backdrops.clone();
+            click.connect_released(move |gesture, _, _, _| {
+                gesture.set_state(gtk4::EventSequenceState::Claimed);
+                win_bd.set_visible(false);
+                for b in &backdrops_bd {
+                    b.set_visible(false);
+                }
+            });
+            backdrop.add_controller(click);
+        }
 
         // Escape key → close menu
         let key_ctrl = gtk4::EventControllerKey::new();
         let win_esc = win.clone();
-        let backdrop_esc = backdrop.clone();
+        let backdrops_esc = backdrops.clone();
         key_ctrl.connect_key_pressed(move |_, key, _, _| {
             if key == gtk4::gdk::Key::Escape {
                 win_esc.set_visible(false);
-                backdrop_esc.set_visible(false);
+                for b in &backdrops_esc {
+                    b.set_visible(false);
+                }
                 gtk4::glib::Propagation::Stop
             } else {
                 gtk4::glib::Propagation::Proceed
@@ -60,14 +68,16 @@ impl DndMenu {
         });
         win.add_controller(key_ctrl);
 
-        backdrop.present();
-        backdrop.set_visible(false);
+        for backdrop in &backdrops {
+            backdrop.present();
+            backdrop.set_visible(false);
+        }
         win.present();
         win.set_visible(false);
 
         Self {
             win,
-            backdrop,
+            backdrops,
             state: Rc::clone(state),
             on_state_change,
         }
@@ -76,10 +86,14 @@ impl DndMenu {
     pub fn toggle(&self) {
         if self.win.is_visible() {
             self.win.set_visible(false);
-            self.backdrop.set_visible(false);
+            for backdrop in &self.backdrops {
+                backdrop.set_visible(false);
+            }
         } else {
             self.rebuild();
-            self.backdrop.set_visible(true);
+            for backdrop in &self.backdrops {
+                backdrop.set_visible(true);
+            }
             self.win.set_visible(true);
         }
     }
@@ -106,7 +120,7 @@ impl DndMenu {
         let state_toggle = Rc::clone(&self.state);
         let on_change_toggle = Rc::clone(&self.on_state_change);
         let win_toggle = self.win.clone();
-        let bd_toggle = self.backdrop.clone();
+        let backdrops_toggle = self.backdrops.clone();
         toggle_btn.connect_clicked(move |_| {
             let new_dnd = !state_toggle.borrow().dnd;
             state_toggle.borrow_mut().dnd = new_dnd;
@@ -114,7 +128,9 @@ impl DndMenu {
             log::info!("DND {}", if new_dnd { "enabled" } else { "disabled" });
             on_change_toggle();
             win_toggle.set_visible(false);
-            bd_toggle.set_visible(false);
+            for b in &backdrops_toggle {
+                b.set_visible(false);
+            }
         });
         vbox.append(&toggle_btn);
 
@@ -148,7 +164,7 @@ impl DndMenu {
                     &self.state,
                     &self.on_state_change,
                     &self.win,
-                    &self.backdrop,
+                    &self.backdrops,
                 );
                 vbox.append(&btn);
             }
@@ -157,10 +173,6 @@ impl DndMenu {
         self.win.set_child(Some(&vbox));
         self.win.set_default_size(-1, -1);
     }
-}
-
-fn setup_backdrop_window(win: &gtk4::ApplicationWindow) {
-    super::window::setup_fullscreen_backdrop(win, "mac-notification-dnd-backdrop");
 }
 
 fn setup_menu_window(win: &gtk4::ApplicationWindow) {
@@ -183,7 +195,7 @@ fn build_timed_dnd_button(
     state: &Rc<RefCell<NotificationState>>,
     on_state_change: &Rc<dyn Fn()>,
     win: &gtk4::ApplicationWindow,
-    backdrop: &gtk4::ApplicationWindow,
+    backdrops: &[gtk4::ApplicationWindow],
 ) -> gtk4::Button {
     let btn = gtk4::Button::with_label(label);
     btn.add_css_class("dnd-menu-item");
@@ -192,7 +204,7 @@ fn build_timed_dnd_button(
     let state_btn = Rc::clone(state);
     let on_change = Rc::clone(on_state_change);
     let win_btn = win.clone();
-    let bd_btn = backdrop.clone();
+    let backdrops_btn: Vec<_> = backdrops.to_vec();
     btn.connect_clicked(move |_| {
         state_btn.borrow_mut().dnd = true;
         let expiry = std::time::SystemTime::now() + std::time::Duration::from_secs(minutes * 60);
@@ -215,7 +227,9 @@ fn build_timed_dnd_button(
 
         on_change();
         win_btn.set_visible(false);
-        bd_btn.set_visible(false);
+        for b in &backdrops_btn {
+            b.set_visible(false);
+        }
     });
 
     btn

--- a/crates/nwg-notifications/src/ui/panel.rs
+++ b/crates/nwg-notifications/src/ui/panel.rs
@@ -9,7 +9,11 @@ use std::rc::Rc;
 /// The slide-out notification history panel.
 pub struct NotificationPanel {
     pub win: gtk4::ApplicationWindow,
-    backdrop: gtk4::ApplicationWindow,
+    /// One transparent backdrop layer-shell surface per monitor.
+    /// Layer-shell pins a surface to a single output, so covering
+    /// multi-monitor click-outside-to-close requires one per monitor
+    /// (issue #55). Toggled as a single logical backdrop.
+    backdrops: Vec<gtk4::ApplicationWindow>,
     revealer: gtk4::Revealer,
     list_box: gtk4::Box,
     state: Rc<RefCell<NotificationState>>,
@@ -25,10 +29,10 @@ impl NotificationPanel {
         on_notification_click: Rc<dyn Fn(u32)>,
         on_state_change: Rc<dyn Fn()>,
     ) -> Self {
-        // Transparent backdrop — catches clicks outside the panel
-        let backdrop = gtk4::ApplicationWindow::new(app);
-        backdrop.add_css_class("notification-backdrop");
-        setup_backdrop_window(&backdrop);
+        // One transparent backdrop per connected monitor — catches clicks
+        // outside the panel on any output (issue #55).
+        let backdrops =
+            super::window::create_fullscreen_backdrops(app, "mac-notification-backdrop");
 
         // Panel window
         let win = gtk4::ApplicationWindow::new(app);
@@ -63,25 +67,29 @@ impl NotificationPanel {
         panel_box.append(&header);
         panel_box.append(&scrolled);
 
-        // Backdrop click → close panel
-        let backdrop_click = gtk4::GestureClick::new();
-        let revealer_bd = revealer.clone();
-        let win_bd = win.clone();
-        let backdrop_bd = backdrop.clone();
-        backdrop_click.connect_released(move |gesture, _, _, _| {
-            gesture.set_state(gtk4::EventSequenceState::Claimed);
-            hide_panel(&revealer_bd, &win_bd, &backdrop_bd);
-        });
-        backdrop.add_controller(backdrop_click);
+        // Backdrop click (on any monitor) → close panel. Every backdrop
+        // shares the same handler via clones; whichever one gets the click
+        // hides the whole set.
+        for backdrop in &backdrops {
+            let backdrop_click = gtk4::GestureClick::new();
+            let revealer_bd = revealer.clone();
+            let win_bd = win.clone();
+            let backdrops_bd = backdrops.clone();
+            backdrop_click.connect_released(move |gesture, _, _, _| {
+                gesture.set_state(gtk4::EventSequenceState::Claimed);
+                hide_panel(&revealer_bd, &win_bd, &backdrops_bd);
+            });
+            backdrop.add_controller(backdrop_click);
+        }
 
         // Escape key → close panel
         let key_ctrl = gtk4::EventControllerKey::new();
         let revealer_esc = revealer.clone();
         let win_esc = win.clone();
-        let backdrop_esc = backdrop.clone();
+        let backdrops_esc = backdrops.clone();
         key_ctrl.connect_key_pressed(move |_, key, _, _| {
             if key == gtk4::gdk::Key::Escape {
-                hide_panel(&revealer_esc, &win_esc, &backdrop_esc);
+                hide_panel(&revealer_esc, &win_esc, &backdrops_esc);
                 gtk4::glib::Propagation::Stop
             } else {
                 gtk4::glib::Propagation::Proceed
@@ -91,7 +99,7 @@ impl NotificationPanel {
 
         let panel = Self {
             win,
-            backdrop,
+            backdrops,
             revealer,
             list_box,
             state: Rc::clone(state),
@@ -100,11 +108,14 @@ impl NotificationPanel {
         };
 
         panel.rebuild();
-        // Present once at startup then immediately hide — establishes the layer surface
+        // Present once at startup then immediately hide — establishes the
+        // layer surface for the panel and each backdrop.
         panel.win.present();
         panel.win.set_visible(false);
-        panel.backdrop.present();
-        panel.backdrop.set_visible(false);
+        for backdrop in &panel.backdrops {
+            backdrop.present();
+            backdrop.set_visible(false);
+        }
 
         panel
     }
@@ -112,19 +123,21 @@ impl NotificationPanel {
     /// Toggles panel visibility with slide animation.
     pub fn toggle(&self) {
         if self.revealer.reveals_child() {
-            hide_panel(&self.revealer, &self.win, &self.backdrop);
+            hide_panel(&self.revealer, &self.win, &self.backdrops);
         } else {
-            // Rebuild, show backdrop + window, then slide in
+            // Rebuild, show backdrops + window, then slide in
             let list = self.list_box.clone();
             let state = Rc::clone(&self.state);
             let on_click = Rc::clone(&self.on_notification_click);
             let on_change = Rc::clone(&self.on_state_change);
             let win = self.win.clone();
-            let backdrop = self.backdrop.clone();
+            let backdrops = self.backdrops.clone();
             let revealer = self.revealer.clone();
             gtk4::glib::idle_add_local_once(move || {
                 rebuild_list(&list, &state, on_click, on_change);
-                backdrop.set_visible(true);
+                for backdrop in &backdrops {
+                    backdrop.set_visible(true);
+                }
                 win.set_visible(true);
                 revealer.set_reveal_child(true);
             });
@@ -147,14 +160,16 @@ impl NotificationPanel {
     }
 }
 
-/// Hides the panel with slide animation and removes the backdrop.
+/// Hides the panel with slide animation and removes all backdrops together.
 fn hide_panel(
     revealer: &gtk4::Revealer,
     win: &gtk4::ApplicationWindow,
-    backdrop: &gtk4::ApplicationWindow,
+    backdrops: &[gtk4::ApplicationWindow],
 ) {
     revealer.set_reveal_child(false);
-    backdrop.set_visible(false);
+    for backdrop in backdrops {
+        backdrop.set_visible(false);
+    }
     let win = win.clone();
     gtk4::glib::timeout_add_local_once(
         std::time::Duration::from_millis(PANEL_REVEAL_DURATION_MS as u64),
@@ -175,10 +190,6 @@ fn setup_panel_window(win: &gtk4::ApplicationWindow) {
     win.set_anchor(gtk4_layer_shell::Edge::Top, true);
     win.set_anchor(gtk4_layer_shell::Edge::Right, true);
     win.set_anchor(gtk4_layer_shell::Edge::Bottom, true);
-}
-
-fn setup_backdrop_window(win: &gtk4::ApplicationWindow) {
-    super::window::setup_fullscreen_backdrop(win, "mac-notification-backdrop");
 }
 
 fn build_header(

--- a/crates/nwg-notifications/src/ui/panel.rs
+++ b/crates/nwg-notifications/src/ui/panel.rs
@@ -31,8 +31,12 @@ impl NotificationPanel {
     ) -> Self {
         // One transparent backdrop per connected monitor — catches clicks
         // outside the panel on any output (issue #55).
-        let backdrops =
-            super::window::create_fullscreen_backdrops(app, "mac-notification-backdrop");
+        let backdrops = nwg_dock_common::layer_shell::create_fullscreen_backdrops(
+            app,
+            "mac-notification-backdrop",
+            "notification-backdrop",
+            None,
+        );
 
         // Panel window
         let win = gtk4::ApplicationWindow::new(app);

--- a/crates/nwg-notifications/src/ui/window.rs
+++ b/crates/nwg-notifications/src/ui/window.rs
@@ -1,5 +1,4 @@
 use crate::config::PopupPosition;
-use gtk4::prelude::*;
 use gtk4_layer_shell::LayerShell;
 
 /// Configures a popup window with layer-shell properties.
@@ -58,59 +57,6 @@ pub fn setup_popup_window(win: &gtk4::ApplicationWindow, position: PopupPosition
     win.set_keyboard_mode(gtk4_layer_shell::KeyboardMode::None);
 }
 
-/// Configures a full-screen transparent backdrop for click-outside-to-close.
-///
-/// Shared by panel and DND menu — anchors all 4 edges, overlay layer, no keyboard.
-/// Pins the surface to a specific monitor so a single layer-shell surface
-/// only covers that one output. Callers that want coverage across all
-/// monitors should use [`create_fullscreen_backdrops`] instead.
-pub fn setup_fullscreen_backdrop(
-    win: &gtk4::ApplicationWindow,
-    namespace: &str,
-    monitor: &gtk4::gdk::Monitor,
-) {
-    win.init_layer_shell();
-    win.set_namespace(Some(namespace));
-    win.set_layer(gtk4_layer_shell::Layer::Overlay);
-    win.set_exclusive_zone(-1);
-    win.set_keyboard_mode(gtk4_layer_shell::KeyboardMode::None);
-    win.set_monitor(Some(monitor));
-    win.set_anchor(gtk4_layer_shell::Edge::Top, true);
-    win.set_anchor(gtk4_layer_shell::Edge::Right, true);
-    win.set_anchor(gtk4_layer_shell::Edge::Bottom, true);
-    win.set_anchor(gtk4_layer_shell::Edge::Left, true);
-}
-
-/// Creates one full-screen transparent backdrop window per connected monitor.
-///
-/// A layer-shell surface only covers the output it's pinned to, so a single
-/// backdrop can't catch clicks on other monitors (issue #55). Callers create
-/// a Vec of these and toggle them together as a single logical backdrop.
-/// If GDK reports no monitors — rare, usually a headless/early-startup
-/// transient — returns an empty Vec and the caller falls back to whatever
-/// degraded behavior makes sense (the panel/menu will still toggle, just
-/// without click-outside-to-close).
-pub fn create_fullscreen_backdrops(
-    app: &gtk4::Application,
-    namespace: &str,
-) -> Vec<gtk4::ApplicationWindow> {
-    let Some(display) = gtk4::gdk::Display::default() else {
-        log::warn!("No default GDK display — backdrops disabled");
-        return Vec::new();
-    };
-    let monitors_model = display.monitors();
-    let mut backdrops = Vec::with_capacity(monitors_model.n_items() as usize);
-    for i in 0..monitors_model.n_items() {
-        let Some(item) = monitors_model.item(i) else {
-            continue;
-        };
-        let Ok(monitor) = item.downcast::<gtk4::gdk::Monitor>() else {
-            continue;
-        };
-        let win = gtk4::ApplicationWindow::new(app);
-        win.add_css_class("notification-backdrop");
-        setup_fullscreen_backdrop(&win, namespace, &monitor);
-        backdrops.push(win);
-    }
-    backdrops
-}
+// Backdrop helpers live in `nwg_dock_common::layer_shell`; the panel and
+// DND menu re-export-by-using them with their own CSS class so the
+// stylesheet for each gets the right opacity.

--- a/crates/nwg-notifications/src/ui/window.rs
+++ b/crates/nwg-notifications/src/ui/window.rs
@@ -1,4 +1,5 @@
 use crate::config::PopupPosition;
+use gtk4::prelude::*;
 use gtk4_layer_shell::LayerShell;
 
 /// Configures a popup window with layer-shell properties.
@@ -60,14 +61,56 @@ pub fn setup_popup_window(win: &gtk4::ApplicationWindow, position: PopupPosition
 /// Configures a full-screen transparent backdrop for click-outside-to-close.
 ///
 /// Shared by panel and DND menu — anchors all 4 edges, overlay layer, no keyboard.
-pub fn setup_fullscreen_backdrop(win: &gtk4::ApplicationWindow, namespace: &str) {
+/// Pins the surface to a specific monitor so a single layer-shell surface
+/// only covers that one output. Callers that want coverage across all
+/// monitors should use [`create_fullscreen_backdrops`] instead.
+pub fn setup_fullscreen_backdrop(
+    win: &gtk4::ApplicationWindow,
+    namespace: &str,
+    monitor: &gtk4::gdk::Monitor,
+) {
     win.init_layer_shell();
     win.set_namespace(Some(namespace));
     win.set_layer(gtk4_layer_shell::Layer::Overlay);
     win.set_exclusive_zone(-1);
     win.set_keyboard_mode(gtk4_layer_shell::KeyboardMode::None);
+    win.set_monitor(Some(monitor));
     win.set_anchor(gtk4_layer_shell::Edge::Top, true);
     win.set_anchor(gtk4_layer_shell::Edge::Right, true);
     win.set_anchor(gtk4_layer_shell::Edge::Bottom, true);
     win.set_anchor(gtk4_layer_shell::Edge::Left, true);
+}
+
+/// Creates one full-screen transparent backdrop window per connected monitor.
+///
+/// A layer-shell surface only covers the output it's pinned to, so a single
+/// backdrop can't catch clicks on other monitors (issue #55). Callers create
+/// a Vec of these and toggle them together as a single logical backdrop.
+/// If GDK reports no monitors — rare, usually a headless/early-startup
+/// transient — returns an empty Vec and the caller falls back to whatever
+/// degraded behavior makes sense (the panel/menu will still toggle, just
+/// without click-outside-to-close).
+pub fn create_fullscreen_backdrops(
+    app: &gtk4::Application,
+    namespace: &str,
+) -> Vec<gtk4::ApplicationWindow> {
+    let Some(display) = gtk4::gdk::Display::default() else {
+        log::warn!("No default GDK display — backdrops disabled");
+        return Vec::new();
+    };
+    let monitors_model = display.monitors();
+    let mut backdrops = Vec::with_capacity(monitors_model.n_items() as usize);
+    for i in 0..monitors_model.n_items() {
+        let Some(item) = monitors_model.item(i) else {
+            continue;
+        };
+        let Ok(monitor) = item.downcast::<gtk4::gdk::Monitor>() else {
+            continue;
+        };
+        let win = gtk4::ApplicationWindow::new(app);
+        win.add_css_class("notification-backdrop");
+        setup_fullscreen_backdrop(&win, namespace, &monitor);
+        backdrops.push(win);
+    }
+    backdrops
 }


### PR DESCRIPTION
Closes #55.

## Summary
- **Notifications panel + DND menu**: click on any monitor now closes them. Previously the single backdrop layer-shell surface only covered the output it was pinned to, so clicks on other monitors never reached it.
- **Drawer**: click on another monitor now closes the drawer too — **when launched with `-k` (OnDemand keyboard mode)**. See caveat below.
- **Extracted shared helper** `nwg_dock_common::layer_shell::create_fullscreen_backdrops` so all three use the same code path. Supports excluding a specific monitor by connector name — used by the drawer (since the drawer itself covers one monitor and a backdrop on the same output would race its surface for clicks).

## Commits
1. **Notifications panel/DND menu fix** (`6b38cf4`) — refactor single-backdrop to `Vec<ApplicationWindow>`, one per monitor, toggled as a logical unit.
2. **Extract to `nwg-dock-common`** (`0bf768b`) — shared helper with monitor-exclusion parameter. No behavior change for notifications.
3. **Drawer fix** (`bd1ea09`) — per-monitor backdrops on all monitors *except* the drawer's own, with click → `on_launch`. Visibility synced via `connect_visible_notify` so every existing show/hide path (signal poller, focus detector, escape handler, close button) picks up backdrops automatically.

## Drawer caveat

Pointer events only reach the drawer's backdrops when the drawer runs with `-k` (KeyboardMode::OnDemand). With the default `KeyboardMode::Exclusive`, Hyprland drops pointer events to all other layer-shell surfaces and the backdrops are visible but inert. This matches the compositor behavior we verified empirically — there's no workaround without changing the drawer's keyboard mode.

The default is **left unchanged** to avoid changing behavior for users who prefer Exclusive (the upstream maintainer's setup is unknown). Users who want cross-monitor close-on-click just pass `-k` in their autostart.

## Visual

Backdrops use `rgba(0, 0, 0, 0.15)` which matches macOS Launchpad's "dim the desktop while the launcher is open" behavior and gives a cue that "drawer is active" across all monitors.

## Test plan
- [x] `cargo test --workspace` — 287 unit tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] SonarQube gate OK (0 new violations)
- [x] Smoke tested notifications panel cross-monitor — confirmed works
- [x] Smoke tested DND menu cross-monitor — should work (same code path)
- [x] Smoke tested drawer cross-monitor with `-k` — confirmed works
- [x] Drawer default (Exclusive) still behaves as before — backdrops are visible but inert, existing focus/poll close paths unchanged
- [ ] Reviewer to smoke test their own config overnight

## Follow-up

Filed #70 for a future Mission Control-style window-grid view (separate scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-monitor backdrops: drawers and notifications create an overlay on every display so clicking outside the UI hides/closes it on any monitor.
  * Backdrops now mirror the main window’s visibility automatically.

* **Refactor**
  * Shared layer-shell helpers moved to a common module for consistent multi-monitor behavior.

* **Style**
  * Added semi-transparent dark backdrop styling for overlays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->