### PR TITLE
Fix ghost dock icons after close on Sway (#62)

### DIFF
--- a/crates/nwg-dock/src/events.rs
+++ b/crates/nwg-dock/src/events.rs
@@ -147,16 +147,24 @@ mod tests {
         assert!(drain_new_events(&rx));
     }
 
-    /// Regression for issue #62: the previous dedup dropped a second event
-    /// carrying the same window id as the last one seen. On Sway that meant
-    /// `close(X)` following `focus(X)` got swallowed, the rebuild never
-    /// fired, and a ghost icon lingered in the dock. Now every real event
-    /// counts as a change; `needs_rebuild` is the source of truth for
-    /// whether the rebuild has actual work to do.
+    /// Regression for issue #62: the previous dedup compared each event's
+    /// id against the last one seen *across polls* — if poll N saw id X
+    /// and poll N+1 also saw id X, the second one got swallowed. That's
+    /// exactly the focused-window-close flow on Sway: `focus(X)` drains
+    /// in poll N, then `close(X)` arrives by poll N+1 and the old code
+    /// dropped it, leaving a ghost icon in the dock until some unrelated
+    /// focus event rebuilt it away.
+    ///
+    /// Splitting into two drain calls is what makes this assertion
+    /// meaningful — both drains receive the same id and both must
+    /// signal a change.
     #[test]
-    fn repeat_id_still_signals_change() {
+    fn repeat_id_across_polls_still_signals_change() {
         let (tx, rx) = mpsc::channel::<String>();
+
         tx.send("0xabc".to_string()).unwrap();
+        assert!(drain_new_events(&rx));
+
         tx.send("0xabc".to_string()).unwrap();
         assert!(drain_new_events(&rx));
     }

--- a/crates/nwg-dock/src/events.rs
+++ b/crates/nwg-dock/src/events.rs
@@ -14,7 +14,7 @@ fn poll_and_rebuild(
     rebuild_fn: &Rc<dyn Fn()>,
 ) {
     let dragging = state.borrow().drag_pending || state.borrow().drag_source_index.is_some();
-    if drain_new_events(receiver, state) && needs_rebuild(state) {
+    if drain_new_events(receiver) && needs_rebuild(state) {
         // Cancel launch animations for apps that now have windows
         crate::ui::launch_bounce::cancel_matched(state);
         if dragging {
@@ -28,14 +28,23 @@ fn poll_and_rebuild(
     }
 }
 
-/// Drains pending window-change events and returns true if a new relevant event was seen.
-fn drain_new_events(receiver: &mpsc::Receiver<String>, state: &Rc<RefCell<DockState>>) -> bool {
+/// Drains pending window-change events and returns true if at least one
+/// real event was seen. Filters out Hyprland layer/redirect lines that
+/// contain `>>` (those are compositor-internal, not window addresses).
+///
+/// Does NOT dedup by window id. The earlier dedup dropped `close(X)`
+/// events that happened to share an id with the preceding `focus(X)`,
+/// which is exactly the close-a-focused-window flow on Sway (issue #62):
+/// user focuses a window, closes it — dedup swallows the close, no
+/// rebuild fires, and the ghost icon lingers until the next unrelated
+/// focus event. `needs_rebuild` already compares the old and new
+/// client class list after an IPC refresh, so it's the authoritative
+/// "do we actually need to rebuild" check — an extra `list_clients`
+/// call per focus event is a cheap price for correctness.
+fn drain_new_events(receiver: &mpsc::Receiver<String>) -> bool {
     let mut changed = false;
     while let Ok(win_addr) = receiver.try_recv() {
-        let last = state.borrow().last_win_addr.clone();
-        // Filter out Hyprland layer/redirect events that aren't real window addresses
-        if win_addr != last && !win_addr.contains(">>") {
-            state.borrow_mut().last_win_addr = win_addr;
+        if !win_addr.contains(">>") {
             changed = true;
         }
     }
@@ -118,4 +127,59 @@ pub fn start_event_listener(
         poll_and_rebuild(&receiver, &state, &rebuild_fn);
         glib::ControlFlow::Continue
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::drain_new_events;
+    use std::sync::mpsc;
+
+    #[test]
+    fn empty_channel_returns_false() {
+        let (_tx, rx) = mpsc::channel::<String>();
+        assert!(!drain_new_events(&rx));
+    }
+
+    #[test]
+    fn single_event_returns_true() {
+        let (tx, rx) = mpsc::channel::<String>();
+        tx.send("0xdeadbeef".to_string()).unwrap();
+        assert!(drain_new_events(&rx));
+    }
+
+    /// Regression for issue #62: the previous dedup dropped a second event
+    /// carrying the same window id as the last one seen. On Sway that meant
+    /// `close(X)` following `focus(X)` got swallowed, the rebuild never
+    /// fired, and a ghost icon lingered in the dock. Now every real event
+    /// counts as a change; `needs_rebuild` is the source of truth for
+    /// whether the rebuild has actual work to do.
+    #[test]
+    fn repeat_id_still_signals_change() {
+        let (tx, rx) = mpsc::channel::<String>();
+        tx.send("0xabc".to_string()).unwrap();
+        tx.send("0xabc".to_string()).unwrap();
+        assert!(drain_new_events(&rx));
+    }
+
+    /// Hyprland's event socket occasionally emits lines that contain `>>`
+    /// (compositor-internal redirects, not window addresses). Those must
+    /// not count as window-change events.
+    #[test]
+    fn layer_redirect_events_ignored() {
+        let (tx, rx) = mpsc::channel::<String>();
+        tx.send("workspace>>2".to_string()).unwrap();
+        tx.send("monitorremoved>>HDMI-A-1".to_string()).unwrap();
+        assert!(!drain_new_events(&rx));
+    }
+
+    /// Mix of real and redirect events — a single real event is enough
+    /// to report "changed".
+    #[test]
+    fn real_event_among_redirects_signals_change() {
+        let (tx, rx) = mpsc::channel::<String>();
+        tx.send("workspace>>2".to_string()).unwrap();
+        tx.send("0xdeadbeef".to_string()).unwrap();
+        tx.send("submap>>default".to_string()).unwrap();
+        assert!(drain_new_events(&rx));
+    }
 }

--- a/crates/nwg-dock/src/state.rs
+++ b/crates/nwg-dock/src/state.rs
@@ -17,9 +17,6 @@ pub struct DockState {
     /// Scaled icon size (adjusted when many apps are open).
     pub img_size_scaled: i32,
 
-    /// Last window id from event stream (used for change detection).
-    pub last_win_addr: String,
-
     /// True when a popover menu is open — prevents autohide.
     pub popover_open: bool,
 
@@ -65,7 +62,6 @@ impl DockState {
             app_dirs,
             compositor,
             img_size_scaled: 48,
-            last_win_addr: String::new(),
             popover_open: false,
             locked: false,
             drag_pending: false,


### PR DESCRIPTION
Addresses the Sway regression reported in #62 by @BlueInGreen68.

## Summary
Stop deduping compositor events by window id in `events.rs`. The previous dedup dropped any event whose id matched the most recently seen one — which is precisely the focused-window-close flow on Sway:

1. Focus vifm → `focus(X)` → drainer records `last=X`, rebuild fires.
2. Close vifm → `close(X)` → `X == last` → event dropped, no rebuild.
3. Ghost icon sits in the dock until an unrelated focus event (e.g. workspace switch) rebuilds.

Hyprland hit the same shape on non-focused-window closes but usually got a follow-up `activewindow(Y)` that papered over the dropped `closewindow(X)` — Sway had no such consolation when the closed window was the focused one on a non-visible workspace.

## Fix
Drop the dedup entirely. `needs_rebuild` already refreshes the client list via IPC and compares class lists — that's the authoritative "does the dock need to re-render" check. One extra `list_clients` round-trip per focus event is cheap relative to correctness on close events.

Also removes the now-unused `last_win_addr` field from `DockState`.

## Test plan
- [x] `cargo test --workspace` — 292 unit tests pass (+5 regression tests for the event drainer: empty channel, single event, same-id repeat, layer-redirect noise, mixed input)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo deny check` — advisories / bans / licenses / sources OK
- [x] SonarQube gate OK (0 new violations)
- [x] Smoke tested locally on Hyprland with dock in non-autohide mode: open/focus/close apps across multiple workspaces, confirmed no ghost icons after close. Focus changes, workspace switches, app launches all still rebuild promptly.
- [ ] @BlueInGreen68 — would appreciate a verification on Sway once this lands if you have time

Fixes #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked rebuild triggering so any real window event causes a rebuild; removed redundant suppression of repeated event IDs and simplified event processing while still ignoring redirect/layer-only events.

* **Tests**
  * Added unit tests covering empty channels, single events, repeated event IDs across polls, redirect-only events being ignored, and mixed redirect/real event behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->