### PR TITLE
Audit & seal nwg-common public API (#82)

### DIFF
--- a/crates/nwg-common/src/compositor/mod.rs
+++ b/crates/nwg-common/src/compositor/mod.rs
@@ -1,34 +1,46 @@
+//! Compositor-neutral IPC abstraction.
+//!
+//! All window-manager IPC flows through the [`Compositor`] trait. Backends
+//! for Hyprland, Sway, and a no-op fallback are private implementation
+//! details; consumers call [`init_or_exit`] or [`init_or_null`] to get a
+//! trait object and only interact with the trait methods and the `Wm*`
+//! types from this module.
+
 mod hyprland;
 mod null;
 mod sway;
-pub mod traits;
-pub mod types;
+mod traits;
+mod types;
 
 use crate::error::{DockError, Result};
-pub use null::NullCompositor;
+use null::NullCompositor;
 pub use traits::{Compositor, WmEventStream};
 pub use types::{WmClient, WmEvent, WmMonitor, WmWorkspace};
 
 /// Supported compositor backends.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CompositorKind {
+pub(crate) enum CompositorKind {
     Hyprland,
     Sway,
 }
 
-/// CLI `--wm` flag values. Uwsm is a launch wrapper that falls through
+/// CLI `--wm` flag values. `Uwsm` is a launch wrapper that falls through
 /// to auto-detection of the actual compositor.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum WmOverride {
+    /// Force the Hyprland backend regardless of environment.
     Hyprland,
+    /// Force the Sway backend regardless of environment.
     Sway,
     /// Universal Wayland Session Manager — launch wrapper, not a compositor.
+    /// Detection falls through to the `HYPRLAND_INSTANCE_SIGNATURE` / `SWAYSOCK`
+    /// env vars as usual.
     Uwsm,
 }
 
 /// Auto-detect the running compositor from environment variables.
 /// Pass `wm_override` to force a specific backend (from `--wm` flag).
-pub fn detect(wm_override: Option<WmOverride>) -> Result<CompositorKind> {
+pub(crate) fn detect(wm_override: Option<WmOverride>) -> Result<CompositorKind> {
     if let Some(wm) = wm_override {
         match wm {
             WmOverride::Hyprland => return Ok(CompositorKind::Hyprland),
@@ -50,7 +62,7 @@ pub fn detect(wm_override: Option<WmOverride>) -> Result<CompositorKind> {
 }
 
 /// Create a compositor backend for the given kind.
-pub fn create(kind: CompositorKind) -> Result<Box<dyn Compositor>> {
+pub(crate) fn create(kind: CompositorKind) -> Result<Box<dyn Compositor>> {
     match kind {
         CompositorKind::Hyprland => Ok(Box::new(hyprland::HyprlandBackend::new()?)),
         CompositorKind::Sway => Ok(Box::new(sway::SwayBackend::new()?)),

--- a/crates/nwg-common/src/compositor/null.rs
+++ b/crates/nwg-common/src/compositor/null.rs
@@ -4,10 +4,11 @@ use crate::error::{DockError, Result};
 
 /// Fallback compositor backend for environments without Hyprland or Sway IPC.
 ///
-/// Used by `nwg-drawer` so it can run on any compositor (Niri, river, Openbox, etc.).
-/// Most methods return errors — the drawer already handles those gracefully.
-/// The one exception is the launch path, which falls back to direct process spawn.
-pub struct NullCompositor;
+/// Returned by [`init_or_null`](super::init_or_null) on drawers that can run
+/// on any compositor (Niri, river, Openbox, etc.). Most methods return errors
+/// — the drawer already handles those gracefully. The one exception is the
+/// launch path, which falls back to direct process spawn.
+pub(crate) struct NullCompositor;
 
 impl Compositor for NullCompositor {
     fn list_clients(&self) -> Result<Vec<WmClient>> {

--- a/crates/nwg-common/src/compositor/types.rs
+++ b/crates/nwg-common/src/compositor/types.rs
@@ -1,39 +1,58 @@
 /// Compositor-neutral window representation.
 #[derive(Debug, Clone, Default)]
 pub struct WmClient {
-    /// Compositor-specific identifier (Hyprland: "0x1234", Sway: "42").
+    /// Compositor-specific identifier (Hyprland: `0x1234`, Sway: `42`).
     pub id: String,
-    /// Application class (Hyprland: class, Sway: app_id or window_properties.class).
+    /// Application class (Hyprland: `class`; Sway: `app_id` or
+    /// `window_properties.class`).
     pub class: String,
     /// Initial class at window creation (Hyprland only). Used to group child
-    /// windows with their parent app (e.g., Playwright browsers under VSCode).
+    /// windows with their parent app (e.g. Playwright browsers under VSCode).
+    /// Empty on backends that don't track this separately.
     pub initial_class: String,
+    /// Human-readable window title.
     pub title: String,
+    /// Process ID of the window's owning process, or 0 if unavailable.
     pub pid: i32,
+    /// Workspace this window lives on.
     pub workspace: WmWorkspace,
+    /// Whether the window is floating (not tiled).
     pub floating: bool,
+    /// ID of the monitor this window is on. Matches [`WmMonitor::id`].
     pub monitor_id: i32,
+    /// Whether the window is currently fullscreen.
     pub fullscreen: bool,
 }
 
 /// Compositor-neutral monitor/output.
 #[derive(Debug, Clone, Default)]
 pub struct WmMonitor {
+    /// Compositor-assigned numeric ID. Matches [`WmClient::monitor_id`].
     pub id: i32,
+    /// Output connector name (e.g. `DP-1`, `eDP-1`).
     pub name: String,
+    /// Physical pixel width.
     pub width: i32,
+    /// Physical pixel height.
     pub height: i32,
+    /// Global x-offset in the compositor's layout.
     pub x: i32,
+    /// Global y-offset in the compositor's layout.
     pub y: i32,
+    /// HiDPI scale factor (1.0 = no scaling).
     pub scale: f64,
+    /// Whether this monitor currently holds keyboard focus.
     pub focused: bool,
+    /// Workspace that's active on this monitor.
     pub active_workspace: WmWorkspace,
 }
 
 /// Compositor-neutral workspace reference.
 #[derive(Debug, Clone, Default)]
 pub struct WmWorkspace {
+    /// Compositor-assigned numeric workspace ID.
     pub id: i32,
+    /// Workspace name (may be numeric-as-string or a human name like `chat`).
     pub name: String,
 }
 

--- a/crates/nwg-common/src/config/mod.rs
+++ b/crates/nwg-common/src/config/mod.rs
@@ -1,3 +1,11 @@
+//! Configuration helpers: CSS loading and hot-reload, CLI flag normalization,
+//! and XDG path resolution.
+
+/// CSS loading, watching, and `@import` graph resolution for GTK4 providers.
 pub mod css;
+
+/// CLI flag normalization for legacy single-dash forms (e.g. `-d` → `--daemon`).
 pub mod flags;
+
+/// XDG data/config/cache directory resolution.
 pub mod paths;

--- a/crates/nwg-common/src/config/paths.rs
+++ b/crates/nwg-common/src/config/paths.rs
@@ -23,7 +23,7 @@ pub fn config_dir(app_name: &str) -> PathBuf {
 }
 
 /// Returns the temp directory, checking TMPDIR/TEMP/TMP then falling back to /tmp.
-pub fn temp_dir() -> PathBuf {
+pub(crate) fn temp_dir() -> PathBuf {
     for var in &["TMPDIR", "TEMP", "TMP"] {
         if let Ok(dir) = env::var(var) {
             return PathBuf::from(dir);
@@ -81,7 +81,3 @@ pub fn load_text_lines(path: &Path) -> std::io::Result<Vec<String>> {
         .collect())
 }
 
-/// Reads a text file and returns its full contents.
-pub fn read_text_file(path: &Path) -> std::io::Result<String> {
-    fs::read_to_string(path)
-}

--- a/crates/nwg-common/src/config/paths.rs
+++ b/crates/nwg-common/src/config/paths.rs
@@ -80,4 +80,3 @@ pub fn load_text_lines(path: &Path) -> std::io::Result<Vec<String>> {
         .filter(|l| !l.is_empty())
         .collect())
 }
-

--- a/crates/nwg-common/src/desktop/categories.rs
+++ b/crates/nwg-common/src/desktop/categories.rs
@@ -1,8 +1,11 @@
 /// A freedesktop application category.
 #[derive(Debug, Clone)]
 pub struct Category {
+    /// Machine-readable category name (e.g. `Development`).
     pub name: String,
+    /// Human-readable label used in the drawer UI (e.g. `Development`).
     pub display_name: String,
+    /// Icon name used to render the category's section header.
     pub icon: String,
 }
 
@@ -20,6 +23,7 @@ const CATEGORY_DEFS: &[(&str, &str, &str)] = &[
     ("Other", "Other", "applications-other"),
 ];
 
+/// Returns the standard freedesktop main-category set the drawer uses.
 pub fn default_categories() -> Vec<Category> {
     CATEGORY_DEFS
         .iter()

--- a/crates/nwg-common/src/desktop/entry.rs
+++ b/crates/nwg-common/src/desktop/entry.rs
@@ -1,21 +1,32 @@
 use std::io::BufRead;
 use std::path::Path;
 
-/// A parsed XDG .desktop file entry.
+/// A parsed XDG `.desktop` file entry.
 #[derive(Debug, Clone, Default)]
 pub struct DesktopEntry {
+    /// The file's desktop ID (basename without `.desktop` suffix).
     pub desktop_id: String,
+    /// The base `Name=` field.
     pub name: String,
+    /// Locale-specific name (e.g. `Name[pl]=…`), if the user's locale matched.
     pub name_loc: String,
+    /// The base `Comment=` field.
     pub comment: String,
+    /// Locale-specific comment, if any.
     pub comment_loc: String,
+    /// The `Icon=` field (name or absolute path).
     pub icon: String,
+    /// The `Exec=` field (with `%U`/`%f`/etc. field codes still present).
     pub exec: String,
+    /// Raw `Categories=` field (semicolon-separated, possibly empty).
     pub category: String,
+    /// `Terminal=true` flag — launch in a terminal emulator.
     pub terminal: bool,
+    /// `NoDisplay=true` flag — entry is hidden from launchers.
     pub no_display: bool,
-    /// StartupWMClass from the .desktop file — used to match compositor window class
-    /// to desktop ID when they differ (e.g. "com.billz.app" → "billz").
+    /// `StartupWMClass=` — used to match compositor window class to desktop ID
+    /// when they differ (e.g. Visual Studio Code's `code.desktop` declares
+    /// `StartupWMClass=Code` because the running window class is `Code`, not `code`).
     pub startup_wm_class: String,
 }
 

--- a/crates/nwg-common/src/desktop/icons.rs
+++ b/crates/nwg-common/src/desktop/icons.rs
@@ -41,9 +41,8 @@ pub fn get_exec(app_name: &str, app_dirs: &[PathBuf]) -> Option<String> {
 
 /// Resolves the display name for an application.
 ///
-/// Returns the locale-aware name (e.g., Name[pl] for Polish) if available,
-/// falling back to the base Name field, then the raw app class name.
-/// Fixes: nwg-piotr/nwg-dock#56 (broken application names)
+/// Returns the locale-aware name (e.g. `Name[pl]` for Polish) if available,
+/// falling back to the base `Name` field, then the raw app class name.
 pub fn get_name(app_name: &str, app_dirs: &[PathBuf]) -> String {
     if let Some(desktop_path) = find_desktop_file(app_name, app_dirs)
         && let Ok(entry) = parse_desktop_file(app_name, &desktop_path)

--- a/crates/nwg-common/src/desktop/mod.rs
+++ b/crates/nwg-common/src/desktop/mod.rs
@@ -1,5 +1,18 @@
+//! `.desktop` file parsing and the surrounding ecosystem: application
+//! directories, icon resolution, FreeDesktop category assignment, and
+//! user-configured preferred-app overrides.
+
+/// FreeDesktop category resolution and the drawer's default category taxonomy.
 pub mod categories;
+
+/// Resolution of `XDG_DATA_DIRS` application directories.
 pub mod dirs;
+
+/// `.desktop` file parsing.
 pub mod entry;
+
+/// Icon file lookup + display-name resolution.
 pub mod icons;
+
+/// User-configured `mime-type → desktop-id` preferred-app overrides.
 pub mod preferred_apps;

--- a/crates/nwg-common/src/error.rs
+++ b/crates/nwg-common/src/error.rs
@@ -1,34 +1,60 @@
 use std::path::PathBuf;
 
-/// Unified error type for dock-common operations.
+/// Unified error type for `nwg-common` fallible operations.
+///
+/// Re-exported at the crate root as `nwg_common::DockError` so consumers
+/// can pattern-match on errors returned by the [`Compositor`](crate::compositor::Compositor)
+/// trait and other public APIs without reaching into an `error` submodule.
 #[derive(Debug, thiserror::Error)]
 pub enum DockError {
+    /// Underlying compositor IPC I/O failure (socket connect, read, write).
     #[error("compositor IPC error: {0}")]
     Ipc(#[from] std::io::Error),
 
+    /// The JSON returned by a compositor IPC query didn't parse into the
+    /// expected type.
     #[error("JSON parse error: {0}")]
     Json(#[from] serde_json::Error),
 
+    /// A `.desktop` file was malformed.
     #[error("desktop entry parse error in {path}: {message}")]
-    DesktopEntry { path: PathBuf, message: String },
+    DesktopEntry {
+        /// Path of the offending file.
+        path: PathBuf,
+        /// Human-readable description of the parse failure.
+        message: String,
+    },
 
+    /// Icon lookup failed — no file matched the requested icon name.
     #[error("icon not found for '{0}'")]
     IconNotFound(String),
 
+    /// An expected data directory (XDG or install-time) wasn't found.
     #[error("data directory not found for '{0}'")]
     DataDirNotFound(String),
 
+    /// Single-instance lock file is already held by another live process.
     #[error("lock file already held: {path} (pid {pid})")]
-    LockFileHeld { path: PathBuf, pid: u32 },
+    LockFileHeld {
+        /// Path to the lock file.
+        path: PathBuf,
+        /// PID of the instance currently holding it.
+        pid: u32,
+    },
 
+    /// A required environment variable was unset — e.g. `HYPRLAND_INSTANCE_SIGNATURE`
+    /// on a Hyprland session.
     #[error("environment variable not set: {0}")]
     EnvNotSet(String),
 
+    /// A `--wm` override specified a backend this library doesn't implement.
     #[error("unsupported compositor: {0}")]
     UnsupportedCompositor(String),
 
+    /// Neither Hyprland nor Sway env vars are set, and no override was given.
     #[error("no compositor detected (set HYPRLAND_INSTANCE_SIGNATURE or SWAYSOCK)")]
     NoCompositorDetected,
 }
 
+/// Shorthand for `std::result::Result<T, DockError>`.
 pub type Result<T> = std::result::Result<T, DockError>;

--- a/crates/nwg-common/src/hyprland/types.rs
+++ b/crates/nwg-common/src/hyprland/types.rs
@@ -61,19 +61,6 @@ pub struct HyprMonitor {
     pub vrr: bool,
 }
 
-/// A Hyprland workspace.
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
-pub struct HyprWorkspace {
-    pub id: i32,
-    pub name: String,
-    pub monitor: String,
-    pub windows: i32,
-    pub hasfullscreen: bool,
-    pub lastwindow: String,
-    pub lastwindowtitle: String,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -106,25 +93,6 @@ mod tests {
         assert_eq!(client.class, "firefox");
         assert_eq!(client.workspace.id, 1);
         assert_eq!(client.pid, 12345);
-    }
-
-    #[test]
-    fn deserialize_workspace() {
-        // Hyprland sends these fields as all-lowercase (no camelCase)
-        let json = r#"{
-            "id": 1,
-            "name": "1",
-            "monitor": "DP-1",
-            "windows": 3,
-            "hasfullscreen": true,
-            "lastwindow": "0xabc",
-            "lastwindowtitle": "Firefox"
-        }"#;
-        let ws: HyprWorkspace = serde_json::from_str(json).unwrap();
-        assert_eq!(ws.id, 1);
-        assert!(ws.hasfullscreen);
-        assert_eq!(ws.lastwindow, "0xabc");
-        assert_eq!(ws.lastwindowtitle, "Firefox");
     }
 
     #[test]

--- a/crates/nwg-common/src/launch.rs
+++ b/crates/nwg-common/src/launch.rs
@@ -1,3 +1,12 @@
+//! Application launching helpers.
+//!
+//! Covers the two paths an app can be started by: directly via
+//! [`std::process::Command`] (for tools like `wl-copy`) or through the
+//! active compositor's `exec` mechanism (so `nwg-dock` / `nwg-drawer`
+//! launches inherit the compositor's session environment). Also hosts
+//! the shared child-reaper thread so GUI app processes don't become
+//! zombies.
+
 use crate::compositor::Compositor;
 use crate::desktop::icons::get_exec;
 use std::path::PathBuf;
@@ -111,7 +120,7 @@ pub fn launch(app_id: &str, app_dirs: &[PathBuf]) {
 }
 
 /// Prepends `GTK_THEME=` to a command if force-theme is enabled.
-pub fn prepend_theme(cmd: &str, theme_prefix: &str) -> String {
+pub(crate) fn prepend_theme(cmd: &str, theme_prefix: &str) -> String {
     if theme_prefix.is_empty() {
         cmd.to_string()
     } else {
@@ -169,7 +178,7 @@ pub fn launch_via_compositor(command: &str, compositor: &dyn Compositor) {
 static USE_UWSM: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 /// Enables uwsm launch mode. Called at startup when `--wm uwsm` is detected.
-pub fn set_uwsm_mode(enabled: bool) {
+pub(crate) fn set_uwsm_mode(enabled: bool) {
     USE_UWSM.store(enabled, std::sync::atomic::Ordering::Relaxed);
     if enabled {
         log::info!("Launch mode: uwsm app --");
@@ -227,14 +236,14 @@ pub fn launch_shell_command(command: &str) {
 }
 
 /// Launches a command with terminal wrapping via the compositor.
-pub fn launch_terminal_via_compositor(command: &str, term: &str, compositor: &dyn Compositor) {
+pub(crate) fn launch_terminal_via_compositor(command: &str, term: &str, compositor: &dyn Compositor) {
     let full = format!("{} -e {}", term, command);
     launch_via_compositor(&full, compositor);
 }
 
 /// Launches a raw command string directly (without WM dispatch).
 /// Uses shell_words::split for POSIX-compliant quoted argument handling.
-pub fn launch_command(command: &str) {
+pub(crate) fn launch_command(command: &str) {
     let elements = split_command(command);
     if elements.is_empty() {
         log::error!("Empty command to launch");

--- a/crates/nwg-common/src/launch.rs
+++ b/crates/nwg-common/src/launch.rs
@@ -236,7 +236,11 @@ pub fn launch_shell_command(command: &str) {
 }
 
 /// Launches a command with terminal wrapping via the compositor.
-pub(crate) fn launch_terminal_via_compositor(command: &str, term: &str, compositor: &dyn Compositor) {
+pub(crate) fn launch_terminal_via_compositor(
+    command: &str,
+    term: &str,
+    compositor: &dyn Compositor,
+) {
     let full = format!("{} -e {}", term, command);
     launch_via_compositor(&full, compositor);
 }

--- a/crates/nwg-common/src/layer_shell.rs
+++ b/crates/nwg-common/src/layer_shell.rs
@@ -13,7 +13,7 @@ use gtk4_layer_shell::LayerShell;
 /// keyboard input. Caller is responsible for adding any CSS class that
 /// gives the window a non-zero background opacity — without that, some
 /// compositors won't deliver pointer events to it.
-pub fn setup_fullscreen_backdrop(
+pub(crate) fn setup_fullscreen_backdrop(
     win: &gtk4::ApplicationWindow,
     namespace: &str,
     monitor: &gtk4::gdk::Monitor,

--- a/crates/nwg-common/src/lib.rs
+++ b/crates/nwg-common/src/lib.rs
@@ -1,3 +1,12 @@
+//! Shared library for the nwg-dock / nwg-drawer / nwg-notifications
+//! Rust ports — compositor-neutral IPC abstraction, `.desktop` entry
+//! parsing, pin-file management, layer-shell helpers, and the various
+//! bits of system plumbing that are common across the three tools.
+//!
+//! See the README for the crate's stability contract.
+
+#![warn(missing_docs)]
+
 pub mod compositor;
 pub mod config;
 pub mod desktop;

--- a/crates/nwg-common/src/lib.rs
+++ b/crates/nwg-common/src/lib.rs
@@ -1,11 +1,14 @@
 pub mod compositor;
 pub mod config;
 pub mod desktop;
-pub mod error;
-pub mod hyprland;
 pub mod launch;
 pub mod layer_shell;
 pub mod pinning;
 pub mod process;
 pub mod signals;
 pub mod singleton;
+
+mod error;
+mod hyprland;
+
+pub use error::{DockError, Result};

--- a/crates/nwg-common/src/pinning.rs
+++ b/crates/nwg-common/src/pinning.rs
@@ -1,3 +1,9 @@
+//! Pinned-app persistence shared between the dock and drawer.
+//!
+//! The cache file stores one desktop ID per line (no `.desktop` suffix).
+//! Writes go through an atomic temp-file-plus-rename so a crash mid-write
+//! never leaves a zero-byte or half-written list.
+
 use std::fs;
 use std::path::Path;
 

--- a/crates/nwg-common/src/process.rs
+++ b/crates/nwg-common/src/process.rs
@@ -1,3 +1,7 @@
+//! Process introspection helpers, primarily for the `--dump-args` flow
+//! used by `make upgrade` to capture a running instance's CLI arguments
+//! before restarting it.
+
 use std::ffi::OsStr;
 use std::fs;
 

--- a/crates/nwg-common/src/signals.rs
+++ b/crates/nwg-common/src/signals.rs
@@ -198,3 +198,83 @@ extern "C" fn sigterm_handler(_: i32) {
     // SAFETY: libc::_exit is async-signal-safe and terminates immediately.
     unsafe { libc::_exit(0) }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rt_offsets_are_stable() {
+        let base = sigrtmin();
+        assert_eq!(sig_toggle(), base + 1);
+        assert_eq!(sig_show(), base + 2);
+        assert_eq!(sig_hide(), base + 3);
+        assert_eq!(sig_notification_toggle(), base + 4);
+        assert_eq!(sig_notification_dnd(), base + 5);
+        assert_eq!(sig_notification_dnd_menu(), base + 6);
+    }
+
+    #[test]
+    fn non_resident_only_accepts_toggle() {
+        assert_eq!(
+            map_signal_to_command(sig_toggle(), false),
+            Some(WindowCommand::Toggle)
+        );
+        assert_eq!(map_signal_to_command(sig_show(), false), None);
+        assert_eq!(map_signal_to_command(sig_hide(), false), None);
+    }
+
+    #[test]
+    fn resident_maps_toggle_show_hide() {
+        assert_eq!(
+            map_signal_to_command(sig_toggle(), true),
+            Some(WindowCommand::Toggle)
+        );
+        assert_eq!(
+            map_signal_to_command(sig_show(), true),
+            Some(WindowCommand::Show)
+        );
+        assert_eq!(
+            map_signal_to_command(sig_hide(), true),
+            Some(WindowCommand::Hide)
+        );
+    }
+
+    #[test]
+    fn sigusr1_maps_to_toggle_for_compat() {
+        // SIGUSR1 is the pre-RT-signals toggle mechanism — still honored
+        // (with a deprecation warning) in both resident and non-resident modes.
+        assert_eq!(
+            map_signal_to_command(libc::SIGUSR1, true),
+            Some(WindowCommand::Toggle)
+        );
+        assert_eq!(
+            map_signal_to_command(libc::SIGUSR1, false),
+            Some(WindowCommand::Toggle)
+        );
+    }
+
+    #[test]
+    fn unknown_signal_returns_none() {
+        assert_eq!(map_signal_to_command(libc::SIGTERM, true), None);
+        assert_eq!(map_signal_to_command(libc::SIGTERM, false), None);
+        // Higher RT signal we don't dispatch on
+        assert_eq!(map_signal_to_command(sigrtmin() + 99, true), None);
+    }
+
+    #[test]
+    fn send_signal_existence_check_on_self() {
+        // `kill(pid, 0)` is the POSIX idiom for "does this PID exist and
+        // can we signal it" without actually delivering a signal.
+        // Our own PID always qualifies.
+        let our_pid = std::process::id();
+        assert!(send_signal_to_pid(our_pid, 0));
+    }
+
+    #[test]
+    fn send_signal_to_invalid_pid_fails() {
+        // PID beyond the kernel's pid_max (4194304) can't exist.
+        let bogus_pid: u32 = 999_999_999;
+        assert!(!send_signal_to_pid(bogus_pid, 0));
+    }
+}

--- a/crates/nwg-common/src/signals.rs
+++ b/crates/nwg-common/src/signals.rs
@@ -8,37 +8,44 @@
 use nix::sys::signal::{self, Signal};
 use std::sync::mpsc;
 
-/// `SIGRTMIN` value on Linux (glibc = 34).
-const SIGRTMIN: i32 = 34;
+/// Returns the runtime `SIGRTMIN` value.
+///
+/// Queried via `libc::SIGRTMIN()` rather than hardcoded to 34 because the
+/// value differs across libc implementations: glibc reserves the first
+/// two RT signals for NPTL (so userspace `SIGRTMIN` = 34), while musl
+/// reserves three (so `SIGRTMIN` = 35).
+fn sigrtmin() -> i32 {
+    libc::SIGRTMIN()
+}
 
-/// Signal used to toggle the dock/drawer window (SIGRTMIN+1).
+/// Signal used to toggle the dock/drawer window (`SIGRTMIN+1`).
 pub fn sig_toggle() -> i32 {
-    SIGRTMIN + 1
+    sigrtmin() + 1
 }
 
-/// Signal used to show the dock/drawer window (SIGRTMIN+2).
+/// Signal used to show the dock/drawer window (`SIGRTMIN+2`).
 pub fn sig_show() -> i32 {
-    SIGRTMIN + 2
+    sigrtmin() + 2
 }
 
-/// Signal used to hide the dock/drawer window (SIGRTMIN+3).
+/// Signal used to hide the dock/drawer window (`SIGRTMIN+3`).
 pub fn sig_hide() -> i32 {
-    SIGRTMIN + 3
+    sigrtmin() + 3
 }
 
-/// Signal used to toggle the notification panel (SIGRTMIN+4).
+/// Signal used to toggle the notification panel (`SIGRTMIN+4`).
 pub fn sig_notification_toggle() -> i32 {
-    SIGRTMIN + 4
+    sigrtmin() + 4
 }
 
-/// Signal used to toggle Do-Not-Disturb (SIGRTMIN+5).
+/// Signal used to toggle Do-Not-Disturb (`SIGRTMIN+5`).
 pub fn sig_notification_dnd() -> i32 {
-    SIGRTMIN + 5
+    sigrtmin() + 5
 }
 
-/// Signal used to show the DND duration menu (SIGRTMIN+6).
+/// Signal used to show the DND duration menu (`SIGRTMIN+6`).
 pub fn sig_notification_dnd_menu() -> i32 {
-    SIGRTMIN + 6
+    sigrtmin() + 6
 }
 
 /// Window visibility commands sent via signal handling.
@@ -84,32 +91,59 @@ pub fn setup_signal_handlers(is_resident: bool) -> mpsc::Receiver<WindowCommand>
     // Block SIGUSR1 and SIGRTMIN+1/2/3 in the main thread BEFORE spawning.
     // Uses raw libc because nix's Signal enum doesn't support RT signals.
     let rt_signals = [sig_toggle(), sig_show(), sig_hide()];
+    // SAFETY: sigset_t is a POD struct, safe to zero-init. The subsequent
+    // sigemptyset/sigaddset/pthread_sigmask calls all take that same stack
+    // pointer; pthread_sigmask passes NULL for the old-mask out-param
+    // because we discard it. Return codes are checked below — failures
+    // only affect our process's signal mask and are non-fatal (the
+    // sigwait thread would simply miss a signal the caller sent).
     unsafe {
         let mut set: libc::sigset_t = std::mem::zeroed();
-        libc::sigemptyset(&mut set);
-        libc::sigaddset(&mut set, libc::SIGUSR1);
-        for &sig in &rt_signals {
-            libc::sigaddset(&mut set, sig);
+        if libc::sigemptyset(&mut set) != 0 {
+            log::error!("sigemptyset failed");
         }
-        libc::pthread_sigmask(libc::SIG_BLOCK, &set, std::ptr::null_mut());
+        if libc::sigaddset(&mut set, libc::SIGUSR1) != 0 {
+            log::error!("sigaddset(SIGUSR1) failed");
+        }
+        for &sig in &rt_signals {
+            if libc::sigaddset(&mut set, sig) != 0 {
+                log::error!("sigaddset({}) failed", sig);
+            }
+        }
+        if libc::pthread_sigmask(libc::SIG_BLOCK, &set, std::ptr::null_mut()) != 0 {
+            log::error!("pthread_sigmask(SIG_BLOCK) failed");
+        }
     }
 
     // Sigwait thread — inherits the blocked signal mask.
     // Build the signal set once before the loop for efficiency.
     std::thread::spawn(move || {
-        // SAFETY: sigset_t is a plain C struct; zeroing + sigemptyset initializes it.
+        // SAFETY: sigset_t is a POD struct, zero-init'd then populated via
+        // sigemptyset/sigaddset on the same stack pointer. Returns are
+        // checked below; a failure here means the thread's local set may
+        // be missing a signal, which will surface as a missed signal —
+        // logged, not aborted.
         let mut set: libc::sigset_t = unsafe { std::mem::zeroed() };
         unsafe {
-            libc::sigemptyset(&mut set);
-            libc::sigaddset(&mut set, libc::SIGUSR1);
+            if libc::sigemptyset(&mut set) != 0 {
+                log::error!("sigemptyset failed in sigwait thread");
+            }
+            if libc::sigaddset(&mut set, libc::SIGUSR1) != 0 {
+                log::error!("sigaddset(SIGUSR1) failed in sigwait thread");
+            }
             for &s in &rt_signals {
-                libc::sigaddset(&mut set, s);
+                if libc::sigaddset(&mut set, s) != 0 {
+                    log::error!("sigaddset({}) failed in sigwait thread", s);
+                }
             }
         }
 
         loop {
             let mut sig: i32 = 0;
-            // SAFETY: sigwait blocks until a signal from the set is pending.
+            // SAFETY: sigwait blocks until a signal from `set` is pending;
+            // `set` was populated above and lives for the duration of the
+            // thread, so the pointer is valid. `sig` is a stack i32 the
+            // kernel writes the fired signal number into.
             let ret = unsafe { libc::sigwait(&set, &mut sig) };
             if ret != 0 {
                 log::error!("sigwait failed with error code {}", ret);
@@ -150,7 +184,13 @@ fn map_signal_to_command(sig: i32, is_resident: bool) -> Option<WindowCommand> {
 
 /// Sends a signal to a running instance by PID.
 pub fn send_signal_to_pid(pid: u32, sig_num: i32) -> bool {
-    // Use raw libc for RT signals since nix doesn't support them
+    // Raw libc is needed because nix's Signal enum doesn't cover RT signals.
+    // SAFETY: libc::kill is a safe syscall wrapper — it never derefs caller
+    // memory and returns -1 + errno for invalid pid/sig. The u32 → i32 cast
+    // can't lose information in practice: kernel PIDs are bounded by
+    // /proc/sys/kernel/pid_max (typically 4194304, well below i32::MAX ≈
+    // 2.1e9). Callers are expected to pass a PID obtained from our own
+    // singleton lock file, validated as a live instance of our binary.
     unsafe { libc::kill(pid as i32, sig_num) == 0 }
 }
 

--- a/crates/nwg-common/src/signals.rs
+++ b/crates/nwg-common/src/signals.rs
@@ -1,31 +1,42 @@
+//! Real-time signal handling for inter-process control.
+//!
+//! The dock, drawer, and notification daemon use `SIGRTMIN+N` signals for
+//! user-driven toggle / show / hide actions. RT signals don't fit into
+//! `nix::sys::signal::Signal`, so this module drops to raw libc for the
+//! RT-specific parts.
+
 use nix::sys::signal::{self, Signal};
 use std::sync::mpsc;
 
-/// SIGRTMIN value on Linux (glibc = 34).
+/// `SIGRTMIN` value on Linux (glibc = 34).
 const SIGRTMIN: i32 = 34;
 
-/// Signal numbers used by dock/drawer for control.
+/// Signal used to toggle the dock/drawer window (SIGRTMIN+1).
 pub fn sig_toggle() -> i32 {
     SIGRTMIN + 1
 }
 
+/// Signal used to show the dock/drawer window (SIGRTMIN+2).
 pub fn sig_show() -> i32 {
     SIGRTMIN + 2
 }
 
+/// Signal used to hide the dock/drawer window (SIGRTMIN+3).
 pub fn sig_hide() -> i32 {
     SIGRTMIN + 3
 }
 
-/// Signal numbers used by the notification daemon.
+/// Signal used to toggle the notification panel (SIGRTMIN+4).
 pub fn sig_notification_toggle() -> i32 {
     SIGRTMIN + 4
 }
 
+/// Signal used to toggle Do-Not-Disturb (SIGRTMIN+5).
 pub fn sig_notification_dnd() -> i32 {
     SIGRTMIN + 5
 }
 
+/// Signal used to show the DND duration menu (SIGRTMIN+6).
 pub fn sig_notification_dnd_menu() -> i32 {
     SIGRTMIN + 6
 }
@@ -33,9 +44,13 @@ pub fn sig_notification_dnd_menu() -> i32 {
 /// Window visibility commands sent via signal handling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WindowCommand {
+    /// Show the window.
     Show,
+    /// Hide the window.
     Hide,
+    /// Toggle visibility; on non-resident programs this means "quit".
     Toggle,
+    /// Quit the program.
     Quit,
 }
 

--- a/crates/nwg-common/src/singleton.rs
+++ b/crates/nwg-common/src/singleton.rs
@@ -1,3 +1,11 @@
+//! Single-instance enforcement via a per-user lock file.
+//!
+//! The lock file stores the PID of the running instance; on startup a
+//! new process reads that PID, confirms the process is still alive and
+//! running our binary, and either refuses to start (returning the
+//! existing PID so the new invocation can signal it instead) or claims
+//! a stale lock when the prior owner is gone.
+
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -55,6 +63,7 @@ pub struct LockFile {
 }
 
 impl LockFile {
+    /// Path of the underlying lock file on disk.
     pub fn path(&self) -> &Path {
         &self.path
     }

--- a/crates/nwg-drawer/src/config.rs
+++ b/crates/nwg-drawer/src/config.rs
@@ -339,10 +339,7 @@ mod tests {
                 .into_iter()
                 .map(String::from),
         ));
-        assert_eq!(
-            config.wm,
-            Some(nwg_common::compositor::WmOverride::Uwsm)
-        );
+        assert_eq!(config.wm, Some(nwg_common::compositor::WmOverride::Uwsm));
     }
 
     #[test]
@@ -352,10 +349,7 @@ mod tests {
                 .into_iter()
                 .map(String::from),
         ));
-        assert_eq!(
-            config.wm,
-            Some(nwg_common::compositor::WmOverride::Uwsm)
-        );
+        assert_eq!(config.wm, Some(nwg_common::compositor::WmOverride::Uwsm));
     }
 
     #[test]

--- a/crates/nwg-notifications/src/config.rs
+++ b/crates/nwg-notifications/src/config.rs
@@ -77,10 +77,7 @@ mod tests {
     #[test]
     fn wm_flag_uwsm() {
         let config = NotificationConfig::parse_from(["test", "--wm", "uwsm"]);
-        assert_eq!(
-            config.wm,
-            Some(nwg_common::compositor::WmOverride::Uwsm)
-        );
+        assert_eq!(config.wm, Some(nwg_common::compositor::WmOverride::Uwsm));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Tightens the library's public surface ahead of its first crates.io publish in Phase 1 of the monorepo split (#80). Every `pub` item is now either documented with rustdoc or deliberately downgraded to `pub(crate)`. `cargo doc --no-deps -p nwg-common` runs warning-free; binaries still compile against the reduced surface.

## What changed

**Sealed modules** (were `pub mod`, now private):
- `hyprland` — top-level IPC types/events only used by `compositor::hyprland` backend
- `error` — now private with `DockError` + `Result` re-exported at the crate root (`nwg_common::DockError` still works, cleaner namespace)
- `compositor::{traits, types}` — items flow through `pub use` re-exports at the `compositor` module root

**Items downgraded to `pub(crate)`:**
- `CompositorKind`, `detect`, `create`, `NullCompositor` — binaries only ever use `init_or_exit` / `init_or_null`
- `launch::{launch_command, launch_terminal_via_compositor, prepend_theme, set_uwsm_mode}` — internal helpers for the public wrappers
- `layer_shell::setup_fullscreen_backdrop` — internal helper for `create_fullscreen_backdrops`
- `config::paths::temp_dir` — only the singleton lock uses it

**Dead code removed:**
- `hyprland::types::HyprWorkspace` struct + its self-test (no constructors outside the test after sealing)
- `config::paths::read_text_file` — one-liner wrapper around `fs::read_to_string` with zero callers

**Docs added:**
- `#![warn(missing_docs)]` on the lib crate
- Crate-level `//!` intro on `lib.rs`
- Module-level `//!` intros on `compositor`, `config`, `desktop`, `launch`, `pinning`, `process`, `signals`, `singleton`, and each `config::*` / `desktop::*` re-export
- Field-by-field docs on `WmClient`, `WmMonitor`, `WmWorkspace`, `DesktopEntry`, `Category`
- Per-variant docs on `DockError`, `WmEvent`, `WmOverride`, `WindowCommand`
- Replaced a personal-name example (`com.billz.app`) with a canonical real-world case (VS Code's `code.desktop` carrying `StartupWMClass=Code`) to illustrate why `startup_wm_class` matters
- Fixed an unresolved-link warning where `Name[pl]` was being parsed as an intra-doc link

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — 360 tests pass
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo doc --no-deps -p nwg-common` — zero warnings
- [x] `cargo deny check` — ok (3 pre-existing `unmatched-skip` warnings in `deny.toml` are unrelated)
- [x] `cargo audit` — exit 0
- [x] Smoke test via `make upgrade` — dock, drawer, notifications restarted + confirmed working
- [ ] CI + CodeRabbit green on this PR

Closes #82.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Richer window, monitor, workspace, and desktop-entry metadata for improved desktop integration
  - New runtime notification signal helpers

* **Improvements**
  - Expanded and clarified crate-, module- and error-type documentation
  - Added descriptive fields for application categories and pinning/process docs

* **Breaking Changes**
  - Removed one public workspace type and made several launcher/util APIs and helpers internal; some utility functions were no longer exported
<!-- end of auto-generated comment: release notes by coderabbit.ai -->