### PR TITLE
Seed nwg-common crates.io metadata + library README (#85)

### DIFF
--- a/crates/nwg-common/Cargo.toml
+++ b/crates/nwg-common/Cargo.toml
@@ -2,8 +2,15 @@
 name = "nwg-common"
 version.workspace = true
 edition = "2024"
-license.workspace = true
-rust-version.workspace = true
+rust-version = "1.95"
+license = "MIT"
+description = "Shared library for nwg-dock, nwg-drawer, and nwg-notifications — compositor-neutral IPC abstraction for Hyprland and Sway, .desktop parsing, CSS hot-reload, and related system plumbing."
+readme = "README.md"
+# Placeholder — updated in Phase 1 of the monorepo split (#80) when this crate
+# gets extracted to its own repo.
+repository = "https://github.com/jasonherald/nwg-common"
+keywords = ["hyprland", "sway", "wayland", "gtk4", "layer-shell"]
+categories = ["gui", "config"]
 
 [dependencies]
 gtk4 = { workspace = true }

--- a/crates/nwg-common/README.md
+++ b/crates/nwg-common/README.md
@@ -57,7 +57,7 @@ you can import is documented. See `cargo doc --open -p nwg-common`.
 
 ## Pre-split history
 
-Prior to v0.3.0, this crate lived inside the
+Before v0.3.0, this crate lived inside the
 [`mac-doc-hyprland`](https://github.com/jasonherald/mac-doc-hyprland)
 monorepo as `nwg-dock-common` at version 0.2.0. The full pre-split git
 history is preserved in the monorepo; this crate's `CHANGELOG.md`

--- a/crates/nwg-common/README.md
+++ b/crates/nwg-common/README.md
@@ -1,0 +1,68 @@
+# nwg-common
+
+Shared library backing the [`nwg-dock`](https://github.com/jasonherald/nwg-dock),
+[`nwg-drawer`](https://github.com/jasonherald/nwg-drawer), and
+[`nwg-notifications`](https://github.com/jasonherald/nwg-notifications) ports —
+the macOS-style dock, app drawer, and notification daemon for
+[Hyprland](https://hyprland.org/) and [Sway](https://swaywm.org/), written in Rust.
+
+## What's in the box
+
+- **Compositor-neutral IPC abstraction.** A `Compositor` trait with Hyprland
+  and Sway backends, auto-detected from `HYPRLAND_INSTANCE_SIGNATURE` /
+  `SWAYSOCK` env vars. A null backend for graceful degradation on unsupported
+  compositors (Niri, river, Openbox, etc.). Consumers call `init_or_exit` or
+  `init_or_null` and only talk to the trait from then on.
+- **`.desktop` file handling.** Parser with locale-aware `Name` / `Comment`
+  resolution, FreeDesktop category assignment with secondary-category
+  mapping, icon file lookup, and user-configured preferred-app overrides.
+- **CSS loading + hot-reload.** GTK4 CssProvider loading with recursive
+  `@import` graph resolution, cycle detection, and an in-place file watcher
+  that survives both truncate-in-place and rename-swap save strategies.
+- **XDG paths.** Data / config / cache directory resolution following the
+  XDG Base Directory spec.
+- **Application launching.** Direct spawn and compositor-`exec` pathways,
+  plus a shared child-reaper thread so GUI-app processes don't zombify.
+  Handles `.desktop` field codes, theme prepends, and terminal launches.
+- **Shared pin file.** Atomic save / load with case-insensitive pin / unpin
+  for the `~/.cache/mac-dock-pinned` file used by the dock and drawer.
+- **RT-signal plumbing.** `SIGRTMIN+1..+6` helpers with runtime `SIGRTMIN`
+  query (correct on glibc and musl), plus SIGTERM and single-instance
+  signaling.
+- **Single-instance lock.** Per-user lock file with stale-PID recovery that
+  validates `/proc/<pid>/exe` against the caller's own binary to avoid
+  acting on recycled PIDs.
+- **Fullscreen layer-shell backdrops.** Per-monitor transparent surfaces
+  for click-outside-to-close UI patterns, across the drawer / notifications
+  panel / DND menu.
+
+## Stability contract
+
+`nwg-common` is in **0.x**. Per crates.io semver convention for `0.x`
+crates:
+
+- Breaking changes ship as **minor** bumps (`0.3 → 0.4`).
+- Additive changes ship as **patch** or **minor** depending on scope.
+- **1.0.0 is a deliberate decision** we'll make once the public API has
+  had real-world soak time across the three binaries that depend on it.
+  Don't expect it imminently — the point of the 0.x window is to let the
+  surface settle.
+
+Binaries consuming `nwg-common` should pin to `nwg-common = "0.3"` (or
+whatever the current minor is) so patch bumps flow automatically while
+minor bumps are opted into deliberately.
+
+The public surface is sealed behind `#![warn(missing_docs)]` — every item
+you can import is documented. See `cargo doc --open -p nwg-common`.
+
+## Pre-split history
+
+Prior to v0.3.0, this crate lived inside the
+[`mac-doc-hyprland`](https://github.com/jasonherald/mac-doc-hyprland)
+monorepo as `nwg-dock-common` at version 0.2.0. The full pre-split git
+history is preserved in the monorepo; this crate's `CHANGELOG.md`
+documents changes from v0.3.0 onward.
+
+## License
+
+MIT. See the `LICENSE` file in the repo root.


### PR DESCRIPTION
## Summary
Fills in the `Cargo.toml` fields crates.io requires for publishing and drops a library-scoped `README.md` for the same crate. `cargo publish --dry-run -p nwg-common` packages cleanly (38 files, 70.1 KiB compressed).

The actual publish is Phase 1 (#93); this PR just ensures the metadata is in place ahead of the extraction.

## What changed
- **`crates/nwg-common/Cargo.toml`**
  - Added: `description`, `readme = "README.md"`, `repository` (placeholder pointing at `jasonherald/nwg-common`, updated for real in Phase 1), `keywords = ["hyprland", "sway", "wayland", "gtk4", "layer-shell"]`, `categories = ["gui", "config"]`.
  - Made `rust-version = "1.95"` and `license = "MIT"` explicit instead of workspace-inherited, so the published crate's `Cargo.toml` is self-contained.
  - `version` stays `workspace = true` (still 0.2.0 in the monorepo); Phase 1 bumps it to 0.3.0 at extraction time.
- **`crates/nwg-common/README.md`** — new.
  - What the library does, module by module.
  - Stability contract: 0.x, minor = breaking per crates.io convention, 1.0 is a deliberate later decision.
  - Pre-split pointer back to the monorepo's git log for pre-0.3.0 history.

## Test plan
- [x] `cargo publish --dry-run -p nwg-common` → packages 38 files, no metadata errors
- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — 367 tests pass (unchanged)
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] CI + CodeRabbit review

No runtime changes → no smoke test required.

Closes #85.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive README describing nwg-common’s capabilities: compositor-agnostic IPC, .desktop parsing, CSS loading with hot-reload, app launching flows, signal utilities, single-instance handling, and backdrop behavior.

* **Chores**
  * Updated package metadata (explicit license, Rust version, and additional fields) to improve discoverability and packaging clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->