### PR TITLE
Add migration-notice banner to monorepo README (#88)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # mac-dock-hyprland
 
+> [!IMPORTANT]
+> **This repo is being split into per-tool repositories.** Tracked in [#80](https://github.com/jasonherald/mac-doc-hyprland/issues/80).
+>
+> The shared library and the three binaries are moving to dedicated repos and will be published individually to crates.io at v0.3.0. Until each extraction lands, the monorepo here remains the source of truth; once a repo exists, this banner will link to it directly.
+>
+> | Tool | New repo | crates.io | Status |
+> |------|----------|-----------|--------|
+> | `nwg-common` (shared library) | _coming in Phase 1_ | _coming in Phase 1_ | planned |
+> | `nwg-dock` (renamed from `nwg-dock-hyprland` — supports both Hyprland and Sway) | _coming in Phase 2_ | _coming in Phase 2_ | planned |
+> | `nwg-drawer` | _coming in Phase 3_ | _coming in Phase 3_ | planned |
+> | `nwg-notifications` | _coming in Phase 4_ | _coming in Phase 4_ | planned |
+>
+> **Heading to the dock?** Current `exec-once = nwg-dock-hyprland …` autostart lines keep working — we're shipping a `nwg-dock-hyprland` symlink alias with the renamed binary so nothing breaks on upgrade.
+
+---
+
 A macOS-style dock, application launcher, and notification center for [Hyprland](https://hyprland.org/) and [Sway](https://swaywm.org/), written in Rust.
 
 Replaces [nwg-dock-hyprland](https://github.com/nwg-piotr/nwg-dock-hyprland), [nwg-drawer](https://github.com/nwg-piotr/nwg-drawer), and [mako](https://github.com/emersion/mako) with a unified, memory-safe implementation.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 > | `nwg-drawer` | [Phase 3: create repo](https://github.com/jasonherald/mac-doc-hyprland/issues/99) | [Phase 3: publish v0.3.0](https://github.com/jasonherald/mac-doc-hyprland/issues/102) | planned |
 > | `nwg-notifications` | [Phase 4: create repo](https://github.com/jasonherald/mac-doc-hyprland/issues/103) | [Phase 4: publish v0.3.0](https://github.com/jasonherald/mac-doc-hyprland/issues/106) | planned |
 >
-> **Heading to the dock?** Current `exec-once = nwg-dock-hyprland …` autostart lines keep working — we're shipping a `nwg-dock-hyprland` symlink alias with the renamed binary so nothing breaks on upgrade.
+> **Heading to the dock?** Nothing's renamed yet — current `exec-once = nwg-dock-hyprland …` autostart lines keep working today because the binary is still called `nwg-dock-hyprland` in this monorepo. When the Phase 2 rename to `nwg-dock` lands, the Makefile will install a `nwg-dock-hyprland` → `nwg-dock` symlink ([tracked in #96](https://github.com/jasonherald/mac-doc-hyprland/issues/96)) so those autostart lines continue to work on upgrade without any config edits.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 >
 > | Tool | New repo | crates.io | Status |
 > |------|----------|-----------|--------|
-> | `nwg-common` (shared library) | _coming in Phase 1_ | _coming in Phase 1_ | planned |
-> | `nwg-dock` (renamed from `nwg-dock-hyprland` — supports both Hyprland and Sway) | _coming in Phase 2_ | _coming in Phase 2_ | planned |
-> | `nwg-drawer` | _coming in Phase 3_ | _coming in Phase 3_ | planned |
-> | `nwg-notifications` | _coming in Phase 4_ | _coming in Phase 4_ | planned |
+> | `nwg-common` (shared library) | [Phase 1: create repo](https://github.com/jasonherald/mac-doc-hyprland/issues/91) | [Phase 1: publish v0.3.0](https://github.com/jasonherald/mac-doc-hyprland/issues/93) | planned |
+> | `nwg-dock` (renamed from `nwg-dock-hyprland` — supports both Hyprland and Sway) | [Phase 2: create repo](https://github.com/jasonherald/mac-doc-hyprland/issues/95) | [Phase 2: publish v0.3.0](https://github.com/jasonherald/mac-doc-hyprland/issues/98) | planned |
+> | `nwg-drawer` | [Phase 3: create repo](https://github.com/jasonherald/mac-doc-hyprland/issues/99) | [Phase 3: publish v0.3.0](https://github.com/jasonherald/mac-doc-hyprland/issues/102) | planned |
+> | `nwg-notifications` | [Phase 4: create repo](https://github.com/jasonherald/mac-doc-hyprland/issues/103) | [Phase 4: publish v0.3.0](https://github.com/jasonherald/mac-doc-hyprland/issues/106) | planned |
 >
 > **Heading to the dock?** Current `exec-once = nwg-dock-hyprland …` autostart lines keep working — we're shipping a `nwg-dock-hyprland` symlink alias with the renamed binary so nothing breaks on upgrade.
 


### PR DESCRIPTION
## Summary
Adds a GitHub-style `[!IMPORTANT]` callout at the top of the root README so anyone landing on the repo during Phase 0–4 sees the split plan up front.

## What's in the banner
- One-line "this repo is being split" statement + link to epic #80.
- A 4-row table (`nwg-common` / `nwg-dock` / `nwg-drawer` / `nwg-notifications`) with columns for new repo URL, crates.io link, and status. All rows currently say _coming in Phase N_; they get filled in as each repo is created in Phases 1–4.
- Explicit callout on the `nwg-dock-hyprland` → `nwg-dock` rename and the symlink alias that keeps existing autostart lines working — the single most-likely "wait, did my upgrade break" moment.

At Phase 7 (#110) this same region becomes the archive notice.

## Test plan
- [x] `cargo fmt --all -- --check` clean (no code touched)
- [ ] GitHub renders the `[!IMPORTANT]` callout (verified after merge)
- [ ] CI + CodeRabbit review

Closes #88.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Announced planned restructuring of the monorepo into separate per-tool repositories with a phased migration roadmap
  * Included a phase table mapping tools to their new repositories and targeted v0.3.0 releases
  * Added a compatibility note confirming existing autostart configurations will continue working via a transition alias mechanism
<!-- end of auto-generated comment: release notes by coderabbit.ai -->