### PR TITLE
Harden CI: add fmt / clippy / test workflows (#119)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -157,16 +157,17 @@ reviews:
       enabled: true
     opengrep:
       enabled: true
-    # TOML formatter / linter — covers the workspace and per-crate Cargo.toml,
-    # rust-toolchain.toml, deny.toml, sonar-project.properties is .properties
-    # not TOML, so taplo skips it.
-    taplo:
-      enabled: true
     # English prose check for long-form docs (README, CHANGELOG, SECURITY.md,
     # CLAUDE.md, doc-comments). Catches typos, awkward phrasing, missing
     # punctuation in user-facing text without being noisy on code.
     languagetool:
       enabled: true
+    # NOTE: taplo (TOML formatter/linter) is not supported by CodeRabbit's
+    # schema v2 (verified against https://coderabbit.ai/integrations/schema.v2.json
+    # — additionalProperties is false and taplo isn't in the 50-tool list).
+    # If we want Cargo.toml linting, add it to `make lint` locally or as its
+    # own CI workflow; CodeRabbit catches Cargo.toml issues via the
+    # **/Cargo.toml path instructions above.
 
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,6 +11,22 @@ reviews:
   collapse_walkthrough: false
   changed_files_summary: true
 
+  # Verify the PR actually addresses the issues it claims to close (catches
+  # "PR #X says it closes #Y but doesn't actually fix it" mismatches).
+  assess_linked_issues: true
+
+  # Auto-cross-link related issues + PRs in the review summary so reviewers
+  # land on relevant context without manual digging — useful as the
+  # multi-repo migration tree (#80) accumulates.
+  related_issues: true
+  related_prs: true
+
+  # Suggest labels in the review summary based on the change. Auto-apply is
+  # off until we define a label taxonomy on the repo (target-repo labels per
+  # #87, area labels, etc.); enable then.
+  suggested_labels: true
+  auto_apply_labels: false
+
   path_filters:
     - "!target/**"
     - "!original/**"
@@ -26,6 +42,7 @@ reviews:
         - No command injection in hyprctl/swaymsg dispatch strings
         - Thread safety: Rc<dyn Compositor> must never cross thread boundaries
         - WmEventStream must be Send (used in background threads)
+        - Wm* types (WmClient, WmMonitor, WmWorkspace, WmEvent) are public API; once #117 lands they will be #[non_exhaustive] with builder construction — never construct via struct literal from outside nwg-common.
     - path: "crates/nwg-common/src/launch.rs"
       instructions: |
         App launching pipeline. Verify:
@@ -47,6 +64,14 @@ reviews:
         - Uses args_os() not args() to avoid panic on non-Unicode argv
         - parse_cmdline_bytes only strips trailing NUL, preserves empty middle args
         - shell_words::join() for safe quoting (handles spaces, nested quotes, single quotes)
+    - path: "crates/nwg-common/src/signals.rs"
+      instructions: |
+        RT signal handling via raw libc. Verify:
+        - sigrtmin() queries libc::SIGRTMIN() at runtime (not hardcoded 34) — musl reserves more NPTL slots than glibc
+        - Every unsafe block has a SAFETY comment explaining invariants
+        - sigemptyset/sigaddset/pthread_sigmask return codes are checked, not silently dropped
+        - Only async-signal-safe operations in handler paths (sigterm_handler uses libc::_exit)
+        - WindowCommand mapping covers SIGUSR1 (legacy) → Toggle compatibility
     - path: "crates/nwg-dock/src/ui/**"
       instructions: |
         Dock UI layer. Verify:
@@ -61,7 +86,7 @@ reviews:
         Drawer UI layer. Verify:
         - All well/category/search builders use WellContext (not 7+ individual params)
         - Pin/unpin operations rollback on save failure
-        - Math evaluation uses meval crate (safe parser, no eval/shell)
+        - Math evaluation uses the exmex crate (migrated off meval in #64; safe parser, no eval/shell)
         - Inline math results don't trap keyboard focus (vbox/row/label non-focusable)
         - CSS dimensions use named constants from constants.rs
         - launch_desktop_entry() for app launches (not inline strip/prepend/launch)
@@ -73,10 +98,14 @@ reviews:
         - ActionInvoked signals emitted correctly on action button click
         - DND state changes fire on_state_change callback
         - Protocol compliance with Desktop Notifications Specification
-    - path: "**/signals.rs"
+    - path: ".github/workflows/*.yml"
       instructions: |
-        Real-time signal handling via raw libc. All unsafe blocks must have
-        SAFETY comments. Only async-signal-safe operations in handler paths.
+        GitHub Actions workflows. Verify:
+        - permissions: block scoped to the minimum (typically `contents: read`); never default-permissive
+        - All third-party actions pinned by full commit SHA, never floating tags (e.g., `actions/checkout@<sha> # v4`, not `@v4`)
+        - No untrusted input (issue/PR title, body, head ref, commit message) interpolated directly into `run:` blocks; route via `env:` if needed
+        - Reasonable `timeout-minutes` set so a hung job doesn't burn an hour of runner time
+        - System-dependency installs (`apt-get install`) use `--no-install-recommends` to keep image lean
     - path: "Makefile"
       instructions: |
         Build system. Verify:
@@ -84,6 +113,23 @@ reviews:
         - Uses target/release/ binaries for --dump-args (not installed binaries which may be old)
         - Fail-fast with || exit 1 on critical steps
         - All PIDs captured per binary (not just first) for multi-instance support
+    - path: "**/CHANGELOG.md"
+      instructions: |
+        Per-crate CHANGELOGs follow Keep a Changelog (https://keepachangelog.com).
+        Verify:
+        - H1 title `# Changelog` (not H2)
+        - `## [x.y.z] — Unreleased` section present and active
+        - User-visible bullets only — implementation-detail churn doesn't earn an entry
+        - Bullets bucketed under Added / Changed / Fixed / Removed / Deprecated as applicable
+        - Per epic #80 §3.4 the project is in 0.x: breaking changes ship as MINOR bumps (0.3 → 0.4), not major
+    - path: "**/Cargo.toml"
+      instructions: |
+        Cargo manifests. Verify:
+        - For publishable crates (the four crates that target crates.io): `description`, `license`, `repository`, `readme`, `keywords`, `categories`, `rust-version` are all explicit (not workspace-inherited) so the published manifest is self-contained
+        - `categories` values must be valid crates.io slugs (verify against https://crates.io/api/v1/category_slugs — e.g. `config` is valid, `configuration` is not)
+        - Dependency version specs follow the project's pinning style (workspace-inherited where possible; explicit `nwg-common = "0.3"` for binaries consuming the published library)
+        - Avoid wildcard `*` versions
+        - `Cargo.lock` is committed for both the library and the binaries (cargo-audit reproducibility)
     - path: "crates/**"
       instructions: |
         General rules for all crates:
@@ -110,6 +156,16 @@ reviews:
     osvScanner:
       enabled: true
     opengrep:
+      enabled: true
+    # TOML formatter / linter — covers the workspace and per-crate Cargo.toml,
+    # rust-toolchain.toml, deny.toml, sonar-project.properties is .properties
+    # not TOML, so taplo skips it.
+    taplo:
+      enabled: true
+    # English prose check for long-form docs (README, CHANGELOG, SECURITY.md,
+    # CLAUDE.md, doc-comments). Catches typos, awkward phrasing, missing
+    # punctuation in user-facing text without being noisy on code.
+    languagetool:
       enabled: true
 
 chat:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -106,6 +106,16 @@ reviews:
         - No untrusted input (issue/PR title, body, head ref, commit message) interpolated directly into `run:` blocks; route via `env:` if needed
         - Reasonable `timeout-minutes` set so a hung job doesn't burn an hour of runner time
         - System-dependency installs (`apt-get install`) use `--no-install-recommends` to keep image lean
+    - path: ".github/actions/**/action.yml"
+      instructions: |
+        GitHub composite / reusable actions. Same security posture as the
+        calling workflows — verify:
+        - All third-party actions pinned by full commit SHA, never floating tags
+        - No untrusted input interpolated directly into `run:` blocks; route via `env:` (`shell: bash` steps are equally vulnerable to injection)
+        - Every `run:` step explicitly declares `shell: bash` (composite-action requirement; missing shell silently breaks the step)
+        - Pinned external sources (git clones, downloads) use immutable refs — commit SHAs for git, checksum verification for binaries
+        - Shell steps quote interpolations defensively (`"$VAR"`, not `$VAR`) and fail fast (`set -e` or `||` chains on critical steps)
+        - System-dependency installs (`apt-get install`) use `--no-install-recommends` to keep image lean
     - path: "Makefile"
       instructions: |
         Build system. Verify:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -98,7 +98,7 @@ reviews:
         - ActionInvoked signals emitted correctly on action button click
         - DND state changes fire on_state_change callback
         - Protocol compliance with Desktop Notifications Specification
-    - path: ".github/workflows/*.yml"
+    - path: ".github/workflows/*.y*ml"
       instructions: |
         GitHub Actions workflows. Verify:
         - permissions: block scoped to the minimum (typically `contents: read`); never default-permissive
@@ -106,7 +106,7 @@ reviews:
         - No untrusted input (issue/PR title, body, head ref, commit message) interpolated directly into `run:` blocks; route via `env:` if needed
         - Reasonable `timeout-minutes` set so a hung job doesn't burn an hour of runner time
         - System-dependency installs (`apt-get install`) use `--no-install-recommends` to keep image lean
-    - path: ".github/actions/**/action.yml"
+    - path: ".github/actions/**/action.y*ml"
       instructions: |
         GitHub composite / reusable actions. Same security posture as the
         calling workflows — verify:

--- a/.github/actions/setup-gtk4/action.yml
+++ b/.github/actions/setup-gtk4/action.yml
@@ -1,0 +1,44 @@
+name: Setup GTK4 + gtk4-layer-shell
+description: |
+  Installs the GTK4 development headers and builds gtk4-layer-shell from
+  source (pinned to an immutable commit SHA). gtk4-layer-shell is not
+  packaged in Ubuntu's default apt repos as of 24.04 noble, so the build
+  step is unavoidable; centralizing it here keeps clippy.yml and test.yml
+  in lock-step.
+
+  To bump gtk4-layer-shell, look up the new tag's commit SHA and replace
+  GTK4_LAYER_SHELL_SHA below. One-liner:
+    curl -sSL https://api.github.com/repos/wmww/gtk4-layer-shell/git/refs/tags/<TAG> | jq -r .object.sha
+
+runs:
+  using: composite
+  steps:
+    - name: Install GTK4 dev + build tools
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          libgtk-4-dev \
+          libwayland-dev \
+          meson \
+          ninja-build
+
+    - name: Build & install gtk4-layer-shell (pinned SHA)
+      shell: bash
+      env:
+        # gtk4-layer-shell v1.3.0
+        GTK4_LAYER_SHELL_SHA: 1c963c51514581c41b9bdae08cdf69171265cdda
+      run: |
+        git clone https://github.com/wmww/gtk4-layer-shell.git /tmp/gtk4-layer-shell
+        git -C /tmp/gtk4-layer-shell checkout "$GTK4_LAYER_SHELL_SHA"
+        cd /tmp/gtk4-layer-shell
+        meson setup build \
+          --buildtype=release \
+          -Dintrospection=false \
+          -Dvapi=false \
+          -Ddocs=false \
+          -Dexamples=false \
+          -Dtests=false
+        ninja -C build
+        sudo ninja -C build install
+        sudo ldconfig

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -10,7 +10,11 @@ permissions:
   contents: read
 
 env:
-  GTK4_LAYER_SHELL_VERSION: v1.3.0
+  # gtk4-layer-shell v1.3.0 commit SHA, pinned for supply-chain safety
+  # (tags can be re-pointed by upstream; commit SHAs cannot).
+  # Bump by replacing with the SHA the new tag resolves to:
+  #   curl -sSL https://api.github.com/repos/wmww/gtk4-layer-shell/git/refs/tags/<TAG> | jq -r .object.sha
+  GTK4_LAYER_SHELL_SHA: 1c963c51514581c41b9bdae08cdf69171265cdda
 
 jobs:
   clippy:
@@ -30,11 +34,12 @@ jobs:
             ninja-build
 
       # gtk4-layer-shell is not packaged in Ubuntu's default apt repos
-      # (checked Ubuntu 24.04 noble). Build from source, pinned by tag.
-      - name: Build & install gtk4-layer-shell ${{ env.GTK4_LAYER_SHELL_VERSION }}
+      # (checked Ubuntu 24.04 noble). Build from source, pinned to an
+      # immutable commit SHA (see env block above for tag → SHA lookup).
+      - name: Build & install gtk4-layer-shell (pinned SHA)
         run: |
-          git clone --depth 1 --branch "$GTK4_LAYER_SHELL_VERSION" \
-            https://github.com/wmww/gtk4-layer-shell.git /tmp/gtk4-layer-shell
+          git clone https://github.com/wmww/gtk4-layer-shell.git /tmp/gtk4-layer-shell
+          git -C /tmp/gtk4-layer-shell checkout "$GTK4_LAYER_SHELL_SHA"
           cd /tmp/gtk4-layer-shell
           meson setup build \
             --buildtype=release \

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,27 @@
+name: Clippy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  clippy:
+    name: cargo clippy -D warnings
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install GTK4 + layer-shell dev packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libgtk-4-dev \
+            libgtk4-layer-shell-dev
+      # rust-toolchain.toml pins the channel + clippy component;
+      # rustup on the runner auto-installs on first cargo invocation.
+      - run: cargo clippy --all-targets --workspace -- -D warnings

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -9,19 +9,44 @@ on:
 permissions:
   contents: read
 
+env:
+  GTK4_LAYER_SHELL_VERSION: v1.3.0
+
 jobs:
   clippy:
     name: cargo clippy -D warnings
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Install GTK4 + layer-shell dev packages
+
+      - name: Install GTK4 dev + build tools
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libgtk-4-dev \
-            libgtk4-layer-shell-dev
+            libwayland-dev \
+            meson \
+            ninja-build
+
+      # gtk4-layer-shell is not packaged in Ubuntu's default apt repos
+      # (checked Ubuntu 24.04 noble). Build from source, pinned by tag.
+      - name: Build & install gtk4-layer-shell ${{ env.GTK4_LAYER_SHELL_VERSION }}
+        run: |
+          git clone --depth 1 --branch "$GTK4_LAYER_SHELL_VERSION" \
+            https://github.com/wmww/gtk4-layer-shell.git /tmp/gtk4-layer-shell
+          cd /tmp/gtk4-layer-shell
+          meson setup build \
+            --buildtype=release \
+            -Dintrospection=false \
+            -Dvapi=false \
+            -Ddocs=false \
+            -Dexamples=false \
+            -Dtests=false
+          ninja -C build
+          sudo ninja -C build install
+          sudo ldconfig
+
       # rust-toolchain.toml pins the channel + clippy component;
       # rustup on the runner auto-installs on first cargo invocation.
       - run: cargo clippy --all-targets --workspace -- -D warnings

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -9,49 +9,14 @@ on:
 permissions:
   contents: read
 
-env:
-  # gtk4-layer-shell v1.3.0 commit SHA, pinned for supply-chain safety
-  # (tags can be re-pointed by upstream; commit SHAs cannot).
-  # Bump by replacing with the SHA the new tag resolves to:
-  #   curl -sSL https://api.github.com/repos/wmww/gtk4-layer-shell/git/refs/tags/<TAG> | jq -r .object.sha
-  GTK4_LAYER_SHELL_SHA: 1c963c51514581c41b9bdae08cdf69171265cdda
-
 jobs:
   clippy:
     name: cargo clippy -D warnings
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Install GTK4 dev + build tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libgtk-4-dev \
-            libwayland-dev \
-            meson \
-            ninja-build
-
-      # gtk4-layer-shell is not packaged in Ubuntu's default apt repos
-      # (checked Ubuntu 24.04 noble). Build from source, pinned to an
-      # immutable commit SHA (see env block above for tag → SHA lookup).
-      - name: Build & install gtk4-layer-shell (pinned SHA)
-        run: |
-          git clone https://github.com/wmww/gtk4-layer-shell.git /tmp/gtk4-layer-shell
-          git -C /tmp/gtk4-layer-shell checkout "$GTK4_LAYER_SHELL_SHA"
-          cd /tmp/gtk4-layer-shell
-          meson setup build \
-            --buildtype=release \
-            -Dintrospection=false \
-            -Dvapi=false \
-            -Ddocs=false \
-            -Dexamples=false \
-            -Dtests=false
-          ninja -C build
-          sudo ninja -C build install
-          sudo ldconfig
-
+      - uses: ./.github/actions/setup-gtk4
       # rust-toolchain.toml pins the channel + clippy component;
       # rustup on the runner auto-installs on first cargo invocation.
       - run: cargo clippy --all-targets --workspace -- -D warnings

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,0 +1,21 @@
+name: Rustfmt
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  fmt:
+    name: cargo fmt --check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      # rust-toolchain.toml pins the channel + components (rustfmt, clippy);
+      # rustup on the runner auto-installs on first cargo invocation.
+      - run: cargo fmt --all -- --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,18 +9,42 @@ on:
 permissions:
   contents: read
 
+env:
+  GTK4_LAYER_SHELL_VERSION: v1.3.0
+
 jobs:
   test:
     name: cargo test --workspace
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Install GTK4 + layer-shell dev packages
+
+      - name: Install GTK4 dev + build tools
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libgtk-4-dev \
-            libgtk4-layer-shell-dev
-      - name: cargo test --workspace
-        run: cargo test --workspace
+            libwayland-dev \
+            meson \
+            ninja-build
+
+      # gtk4-layer-shell is not packaged in Ubuntu's default apt repos
+      # (checked Ubuntu 24.04 noble). Build from source, pinned by tag.
+      - name: Build & install gtk4-layer-shell ${{ env.GTK4_LAYER_SHELL_VERSION }}
+        run: |
+          git clone --depth 1 --branch "$GTK4_LAYER_SHELL_VERSION" \
+            https://github.com/wmww/gtk4-layer-shell.git /tmp/gtk4-layer-shell
+          cd /tmp/gtk4-layer-shell
+          meson setup build \
+            --buildtype=release \
+            -Dintrospection=false \
+            -Dvapi=false \
+            -Ddocs=false \
+            -Dexamples=false \
+            -Dtests=false
+          ninja -C build
+          sudo ninja -C build install
+          sudo ldconfig
+
+      - run: cargo test --workspace

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,47 +9,12 @@ on:
 permissions:
   contents: read
 
-env:
-  # gtk4-layer-shell v1.3.0 commit SHA, pinned for supply-chain safety
-  # (tags can be re-pointed by upstream; commit SHAs cannot).
-  # Bump by replacing with the SHA the new tag resolves to:
-  #   curl -sSL https://api.github.com/repos/wmww/gtk4-layer-shell/git/refs/tags/<TAG> | jq -r .object.sha
-  GTK4_LAYER_SHELL_SHA: 1c963c51514581c41b9bdae08cdf69171265cdda
-
 jobs:
   test:
     name: cargo test --workspace
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Install GTK4 dev + build tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libgtk-4-dev \
-            libwayland-dev \
-            meson \
-            ninja-build
-
-      # gtk4-layer-shell is not packaged in Ubuntu's default apt repos
-      # (checked Ubuntu 24.04 noble). Build from source, pinned to an
-      # immutable commit SHA (see env block above for tag → SHA lookup).
-      - name: Build & install gtk4-layer-shell (pinned SHA)
-        run: |
-          git clone https://github.com/wmww/gtk4-layer-shell.git /tmp/gtk4-layer-shell
-          git -C /tmp/gtk4-layer-shell checkout "$GTK4_LAYER_SHELL_SHA"
-          cd /tmp/gtk4-layer-shell
-          meson setup build \
-            --buildtype=release \
-            -Dintrospection=false \
-            -Dvapi=false \
-            -Ddocs=false \
-            -Dexamples=false \
-            -Dtests=false
-          ninja -C build
-          sudo ninja -C build install
-          sudo ldconfig
-
+      - uses: ./.github/actions/setup-gtk4
       - run: cargo test --workspace

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,11 @@ permissions:
   contents: read
 
 env:
-  GTK4_LAYER_SHELL_VERSION: v1.3.0
+  # gtk4-layer-shell v1.3.0 commit SHA, pinned for supply-chain safety
+  # (tags can be re-pointed by upstream; commit SHAs cannot).
+  # Bump by replacing with the SHA the new tag resolves to:
+  #   curl -sSL https://api.github.com/repos/wmww/gtk4-layer-shell/git/refs/tags/<TAG> | jq -r .object.sha
+  GTK4_LAYER_SHELL_SHA: 1c963c51514581c41b9bdae08cdf69171265cdda
 
 jobs:
   test:
@@ -30,11 +34,12 @@ jobs:
             ninja-build
 
       # gtk4-layer-shell is not packaged in Ubuntu's default apt repos
-      # (checked Ubuntu 24.04 noble). Build from source, pinned by tag.
-      - name: Build & install gtk4-layer-shell ${{ env.GTK4_LAYER_SHELL_VERSION }}
+      # (checked Ubuntu 24.04 noble). Build from source, pinned to an
+      # immutable commit SHA (see env block above for tag → SHA lookup).
+      - name: Build & install gtk4-layer-shell (pinned SHA)
         run: |
-          git clone --depth 1 --branch "$GTK4_LAYER_SHELL_VERSION" \
-            https://github.com/wmww/gtk4-layer-shell.git /tmp/gtk4-layer-shell
+          git clone https://github.com/wmww/gtk4-layer-shell.git /tmp/gtk4-layer-shell
+          git -C /tmp/gtk4-layer-shell checkout "$GTK4_LAYER_SHELL_SHA"
           cd /tmp/gtk4-layer-shell
           meson setup build \
             --buildtype=release \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: cargo test --workspace
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install GTK4 + layer-shell dev packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libgtk-4-dev \
+            libgtk4-layer-shell-dev
+      - name: cargo test --workspace
+        run: cargo test --workspace

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Intentional differences from the original Go nwg-dock-hyprland and nwg-drawer:
 
 ## Contributing
 
-PRs are welcome — main is protected, so please open a PR from a feature branch. Run `make lint` (fmt + clippy + test + deny + audit) locally before requesting review. CI runs a subset via separate workflows — `cargo-deny` (`.github/workflows/deny.yml`), `cargo-audit` (`audit.yml`), and CodeQL (`codeql.yml`) — plus CodeRabbit review; fmt / clippy / `cargo test` are not currently enforced in CI, so please ensure `make lint` is green locally.
+PRs are welcome — main is protected, so please open a PR from a feature branch. Run `make lint` (fmt + clippy + test + deny + audit) locally before requesting review. CI runs the equivalent checks via separate workflows — Rustfmt (`fmt.yml`), Clippy with `-D warnings` (`clippy.yml`), `cargo test --workspace` (`test.yml`), `cargo-deny` (`deny.yml`), `cargo-audit` (`audit.yml`), and CodeQL (`codeql.yml`) — plus CodeRabbit review.
 
 **Changelog entries are expected on every user-visible PR.** Each crate that maintains its own CHANGELOG (starting with `nwg-common` — see `crates/nwg-common/CHANGELOG.md`) follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Add a bullet under the `## [x.y.z] — Unreleased` section in the relevant crate's changelog covering what changed for the user, not the implementation details. Internal refactors and test-only changes may skip the entry.
 


### PR DESCRIPTION
## Summary
Brings CI coverage in line with what `make lint` runs locally. Prior to this, only cargo-deny, cargo-audit, and CodeQL were enforced in CI — fmt / clippy / `cargo test` were on the honor system, which meant a PR author skipping `make lint` could land a clippy regression or a broken test and only CodeRabbit would catch it.

Prerequisite for #89 (security-posture template extraction) so each new per-tool repo inherits the full CI set from day one.

## What's added

| Workflow | Job | Timeout | System deps |
|----------|-----|---------|-------------|
| `fmt.yml` | `cargo fmt --all -- --check` | 5 min | none |
| `clippy.yml` | `cargo clippy --all-targets --workspace -- -D warnings` | 20 min | `libgtk-4-dev` + `libgtk4-layer-shell-dev` |
| `test.yml` | `cargo test --workspace` | 20 min | same as clippy |

All three:
- Trigger on `push: branches: [main]` and `pull_request: branches: [main]`, matching the existing deny/audit/codeql workflows.
- Scope `permissions: contents: read` only.
- Pin `actions/checkout` by commit SHA (same SHA as other workflows).
- Rely on `rust-toolchain.toml` (channel `1.95.0`, components `[rustfmt, clippy]`) for auto-install — no explicit `rustup component add` needed.

## Also touched
- `README.md` Contributing section — removes the "fmt / clippy / `cargo test` are not currently enforced in CI" caveat since the workflows here make it enforced. Now lists all six CI workflows (fmt + clippy + test + deny + audit + CodeQL).

## Follow-up (not in this PR)
- Update branch protection on `main` to require Rustfmt / Clippy / Test as status checks. Has to happen *after* these workflows have run at least once so GitHub recognizes them.

## Test plan
- [x] `cargo fmt --all -- --check` clean locally (no code touched)
- [x] **First run of each workflow on this PR passes** — this is the real test
- [x] CI + CodeRabbit review
- [ ] Post-merge: add status-check requirements in branch protection settings

Closes #119.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI workflows to enforce formatting, strict linting (treat warnings as errors), and workspace tests; added an automated step to provision GTK4 build dependencies.
  * Expanded review automation and verification rules, cross-linking of related issues/PRs, and suggested-label guidance.

* **Documentation**
  * Updated contributing docs to list the newly enforced CI checks and their verification coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->