### PR TITLE
Extract security-posture template under docs/security-template/ (#89)

### DIFF
--- a/.github/actions/setup-gtk4/action.yml
+++ b/.github/actions/setup-gtk4/action.yml
@@ -29,6 +29,9 @@ runs:
         # gtk4-layer-shell v1.3.0
         GTK4_LAYER_SHELL_SHA: 1c963c51514581c41b9bdae08cdf69171265cdda
       run: |
+        # Idempotent: remove any prior clone so reused runners (self-hosted
+        # or retried jobs) don't fail on `git clone` into an existing dir.
+        rm -rf /tmp/gtk4-layer-shell
         git clone https://github.com/wmww/gtk4-layer-shell.git /tmp/gtk4-layer-shell
         git -C /tmp/gtk4-layer-shell checkout "$GTK4_LAYER_SHELL_SHA"
         cd /tmp/gtk4-layer-shell

--- a/deny.toml
+++ b/deny.toml
@@ -29,6 +29,11 @@ allow = [
     "MPL-2.0",
     "Unicode-3.0",
     "Unlicense",
+    # Common permissive licenses that occasionally surface via C-binding
+    # and compression dep chains. Added preemptively so a routine
+    # `cargo update` doesn't break `cargo-deny` on an otherwise fine dep.
+    "BSD-3-Clause",
+    "Zlib",
 ]
 confidence-threshold = 0.8
 exceptions = []

--- a/docs/security-template/.coderabbit.yaml
+++ b/docs/security-template/.coderabbit.yaml
@@ -1,0 +1,196 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: "en-US"
+tone_instructions: "Professional, concise. Prioritize idiomatic Rust, safety, correctness, GTK4/Wayland best practices. macOS-style dock/drawer/notifications for Hyprland/Sway, ported from Go."
+
+reviews:
+  profile: "assertive"
+  high_level_summary: true
+  sequence_diagrams: false
+  poem: false
+  collapse_walkthrough: false
+  changed_files_summary: true
+
+  # Verify the PR actually addresses the issues it claims to close (catches
+  # "PR #X says it closes #Y but doesn't actually fix it" mismatches).
+  assess_linked_issues: true
+
+  # Auto-cross-link related issues + PRs in the review summary so reviewers
+  # land on relevant context without manual digging — useful as the
+  # multi-repo migration tree (#80) accumulates.
+  related_issues: true
+  related_prs: true
+
+  # Suggest labels in the review summary based on the change. Auto-apply is
+  # off until we define a label taxonomy on the repo (target-repo labels per
+  # #87, area labels, etc.); enable then.
+  suggested_labels: true
+  auto_apply_labels: false
+
+  path_filters:
+    - "!target/**"
+    - "!original/**"
+
+  path_instructions:
+    - path: "crates/nwg-common/src/compositor/**"
+      instructions: |
+        Compositor abstraction layer. Verify:
+        - All IPC goes through the Compositor trait, never direct hyprland calls from binaries
+        - WmEvent variants are handled exhaustively in match arms
+        - MonitorChanged events parsed for both Hyprland (monitoraddedv2/monitorremoved) and Sway (output events)
+        - Sway i3-ipc message parsing validates magic bytes and payload size
+        - No command injection in hyprctl/swaymsg dispatch strings
+        - Thread safety: Rc<dyn Compositor> must never cross thread boundaries
+        - WmEventStream must be Send (used in background threads)
+        - Wm* types (WmClient, WmMonitor, WmWorkspace, WmEvent) are public API; once #117 lands they will be #[non_exhaustive] with builder construction — never construct via struct literal from outside nwg-common.
+    - path: "crates/nwg-common/src/launch.rs"
+      instructions: |
+        App launching pipeline. Verify:
+        - All spawned Child processes are passed to reap_child() or spawn_and_forget() — no dropped Children
+        - shell_words::split() used for POSIX command splitting (not split_whitespace)
+        - Quotes preserved end-to-end (PR #11 fix)
+        - extract_env_prefix validates POSIX identifiers (no digit-start keys)
+        - Mutex guard dropped before any blocking wait in enqueue_or_reap_sync
+    - path: "crates/nwg-common/src/desktop/**"
+      instructions: |
+        Desktop file parsing and icon resolution. Verify:
+        - strip_field_codes removes only freedesktop-spec field codes (%u, %F, etc.)
+        - %% is collapsed to literal %
+        - Exec field quotes are preserved (never stripped at parse time)
+        - Malformed .desktop files handled gracefully (no panics)
+    - path: "crates/nwg-common/src/process.rs"
+      instructions: |
+        Process utility for --dump-args. Verify:
+        - Uses args_os() not args() to avoid panic on non-Unicode argv
+        - parse_cmdline_bytes only strips trailing NUL, preserves empty middle args
+        - shell_words::join() for safe quoting (handles spaces, nested quotes, single quotes)
+    - path: "crates/nwg-common/src/signals.rs"
+      instructions: |
+        RT signal handling via raw libc. Verify:
+        - sigrtmin() queries libc::SIGRTMIN() at runtime (not hardcoded 34) — musl reserves more NPTL slots than glibc
+        - Every unsafe block has a SAFETY comment explaining invariants
+        - sigemptyset/sigaddset/pthread_sigmask return codes are checked, not silently dropped
+        - Only async-signal-safe operations in handler paths (sigterm_handler uses libc::_exit)
+        - WindowCommand mapping covers SIGUSR1 (legacy) → Toggle compatibility
+    - path: "crates/nwg-dock/src/ui/**"
+      instructions: |
+        Dock UI layer. Verify:
+        - GestureDrag uses DRAG_CLAIM_THRESHOLD before calling set_state(Claimed)
+        - Threshold only gates initial transition — once dragging, all motion processed
+        - No index-based window↔monitor mapping (use output_name from MonitorDock)
+        - Autohide respects drag_source_index and popover_open state
+        - All UI dimensions use named constants from constants.rs
+        - Rc/Weak patterns: watch for reference cycles in rebuild_fn
+    - path: "crates/nwg-drawer/src/ui/**"
+      instructions: |
+        Drawer UI layer. Verify:
+        - All well/category/search builders use WellContext (not 7+ individual params)
+        - Pin/unpin operations rollback on save failure
+        - Math evaluation uses the exmex crate (migrated off meval in #64; safe parser, no eval/shell)
+        - Inline math results don't trap keyboard focus (vbox/row/label non-focusable)
+        - CSS dimensions use named constants from constants.rs
+        - launch_desktop_entry() for app launches (not inline strip/prepend/launch)
+    - path: "crates/nwg-notifications/src/**"
+      instructions: |
+        Notification daemon. Verify:
+        - D-Bus server uses gio bus_own_name (no async bridge)
+        - Backdrop windows have non-zero opacity for input delivery
+        - ActionInvoked signals emitted correctly on action button click
+        - DND state changes fire on_state_change callback
+        - Protocol compliance with Desktop Notifications Specification
+    - path: ".github/workflows/*.y*ml"
+      instructions: |
+        GitHub Actions workflows. Verify:
+        - permissions: block scoped to the minimum (typically `contents: read`); never default-permissive
+        - All third-party actions pinned by full commit SHA, never floating tags (e.g., `actions/checkout@<sha> # v4`, not `@v4`)
+        - No untrusted input (issue/PR title, body, head ref, commit message) interpolated directly into `run:` blocks; route via `env:` if needed
+        - Reasonable `timeout-minutes` set so a hung job doesn't burn an hour of runner time
+        - System-dependency installs (`apt-get install`) use `--no-install-recommends` to keep image lean
+    - path: ".github/actions/**/action.y*ml"
+      instructions: |
+        GitHub composite / reusable actions. Same security posture as the
+        calling workflows — verify:
+        - All third-party actions pinned by full commit SHA, never floating tags
+        - No untrusted input interpolated directly into `run:` blocks; route via `env:` (`shell: bash` steps are equally vulnerable to injection)
+        - Every `run:` step explicitly declares `shell: bash` (composite-action requirement; missing shell silently breaks the step)
+        - Pinned external sources (git clones, downloads) use immutable refs — commit SHAs for git, checksum verification for binaries
+        - Shell steps quote interpolations defensively (`"$VAR"`, not `$VAR`) and fail fast (`set -e` or `||` chains on critical steps)
+        - System-dependency installs (`apt-get install`) use `--no-install-recommends` to keep image lean
+    - path: "Makefile"
+      instructions: |
+        Build system. Verify:
+        - make upgrade captures running process args via --dump-args before stopping
+        - Uses target/release/ binaries for --dump-args (not installed binaries which may be old)
+        - Fail-fast with || exit 1 on critical steps
+        - All PIDs captured per binary (not just first) for multi-instance support
+    - path: "**/CHANGELOG.md"
+      instructions: |
+        Per-crate CHANGELOGs follow Keep a Changelog (https://keepachangelog.com).
+        Verify:
+        - H1 title `# Changelog` (not H2)
+        - `## [x.y.z] — Unreleased` section present and active
+        - User-visible bullets only — implementation-detail churn doesn't earn an entry
+        - Bullets bucketed under Added / Changed / Fixed / Removed / Deprecated as applicable
+        - Per epic #80 §3.4 the project is in 0.x: breaking changes ship as MINOR bumps (0.3 → 0.4), not major
+    - path: "**/Cargo.toml"
+      instructions: |
+        Cargo manifests. Verify:
+        - For publishable crates (the four crates that target crates.io): `description`, `license`, `repository`, `readme`, `keywords`, `categories`, `rust-version` are all explicit (not workspace-inherited) so the published manifest is self-contained
+        - `categories` values must be valid crates.io slugs (verify against https://crates.io/api/v1/category_slugs — e.g. `config` is valid, `configuration` is not)
+        - Dependency version specs follow the project's pinning style (workspace-inherited where possible; explicit `nwg-common = "0.3"` for binaries consuming the published library)
+        - Avoid wildcard `*` versions
+        - `Cargo.lock` is committed for both the library and the binaries (cargo-audit reproducibility)
+    - path: "crates/**"
+      instructions: |
+        General rules for all crates:
+        - No unwrap() in library code (use proper error handling)
+        - Log errors, never silently discard with let _ = (except optional wl-copy)
+        - No #[allow(dead_code)] — all code should be used
+        - No magic numbers — use named constants or inline comments
+        - Unsafe code only in signals.rs/listeners.rs with SAFETY comments
+        - Tests at bottom of file in #[cfg(test)] mod tests, test behavior not implementation
+
+  tools:
+    clippy:
+      enabled: true
+    gitleaks:
+      enabled: true
+    markdownlint:
+      enabled: true
+    yamllint:
+      enabled: true
+    actionlint:
+      enabled: true
+    shellcheck:
+      enabled: true
+    osvScanner:
+      enabled: true
+    opengrep:
+      enabled: true
+    # English prose check for long-form docs (README, CHANGELOG, SECURITY.md,
+    # CLAUDE.md, doc-comments). Catches typos, awkward phrasing, missing
+    # punctuation in user-facing text without being noisy on code.
+    languagetool:
+      enabled: true
+    # NOTE: taplo (TOML formatter/linter) is not supported by CodeRabbit's
+    # schema v2 (verified against https://coderabbit.ai/integrations/schema.v2.json
+    # — additionalProperties is false and taplo isn't in the 50-tool list).
+    # If we want Cargo.toml linting, add it to `make lint` locally or as its
+    # own CI workflow; CodeRabbit catches Cargo.toml issues via the
+    # **/Cargo.toml path instructions above.
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  opt_out: false
+  learnings:
+    scope: "local"
+  issues:
+    scope: "local"
+  pull_requests:
+    scope: "local"
+  web_search:
+    enabled: true
+  code_guidelines:
+    enabled: true

--- a/docs/security-template/.env.example
+++ b/docs/security-template/.env.example
@@ -1,0 +1,11 @@
+# Copy this file to `.env` (which is gitignored) and fill in real values.
+# The `.env` file is consumed by `make sonar` to authenticate against the
+# SonarQube server; everything else can run without it.
+
+# Project analysis token — generated per-project in SonarQube web UI.
+# See `docs/security-template/CHECKLIST.md` step 4 for how to create one
+# in the shared template, or the CHECKLIST.md in the per-tool repo root.
+SONAR_TOKEN=
+
+# SonarQube server URL — unchanged across repos unless the server moves.
+SONAR_HOST_URL=https://sonar.aaru.network

--- a/docs/security-template/.github/actions/setup-gtk4/action.yml
+++ b/docs/security-template/.github/actions/setup-gtk4/action.yml
@@ -1,0 +1,44 @@
+name: Setup GTK4 + gtk4-layer-shell
+description: |
+  Installs the GTK4 development headers and builds gtk4-layer-shell from
+  source (pinned to an immutable commit SHA). gtk4-layer-shell is not
+  packaged in Ubuntu's default apt repos as of 24.04 noble, so the build
+  step is unavoidable; centralizing it here keeps clippy.yml and test.yml
+  in lock-step.
+
+  To bump gtk4-layer-shell, look up the new tag's commit SHA and replace
+  GTK4_LAYER_SHELL_SHA below. One-liner:
+    curl -sSL https://api.github.com/repos/wmww/gtk4-layer-shell/git/refs/tags/<TAG> | jq -r .object.sha
+
+runs:
+  using: composite
+  steps:
+    - name: Install GTK4 dev + build tools
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          libgtk-4-dev \
+          libwayland-dev \
+          meson \
+          ninja-build
+
+    - name: Build & install gtk4-layer-shell (pinned SHA)
+      shell: bash
+      env:
+        # gtk4-layer-shell v1.3.0
+        GTK4_LAYER_SHELL_SHA: 1c963c51514581c41b9bdae08cdf69171265cdda
+      run: |
+        git clone https://github.com/wmww/gtk4-layer-shell.git /tmp/gtk4-layer-shell
+        git -C /tmp/gtk4-layer-shell checkout "$GTK4_LAYER_SHELL_SHA"
+        cd /tmp/gtk4-layer-shell
+        meson setup build \
+          --buildtype=release \
+          -Dintrospection=false \
+          -Dvapi=false \
+          -Ddocs=false \
+          -Dexamples=false \
+          -Dtests=false
+        ninja -C build
+        sudo ninja -C build install
+        sudo ldconfig

--- a/docs/security-template/.github/actions/setup-gtk4/action.yml
+++ b/docs/security-template/.github/actions/setup-gtk4/action.yml
@@ -29,6 +29,9 @@ runs:
         # gtk4-layer-shell v1.3.0
         GTK4_LAYER_SHELL_SHA: 1c963c51514581c41b9bdae08cdf69171265cdda
       run: |
+        # Idempotent: remove any prior clone so reused runners (self-hosted
+        # or retried jobs) don't fail on `git clone` into an existing dir.
+        rm -rf /tmp/gtk4-layer-shell
         git clone https://github.com/wmww/gtk4-layer-shell.git /tmp/gtk4-layer-shell
         git -C /tmp/gtk4-layer-shell checkout "$GTK4_LAYER_SHELL_SHA"
         cd /tmp/gtk4-layer-shell

--- a/docs/security-template/.github/workflows/audit.yml
+++ b/docs/security-template/.github/workflows/audit.yml
@@ -1,0 +1,25 @@
+name: Security Audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run weekly on Monday at 06:00 UTC
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    name: Dependency Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/security-template/.github/workflows/clippy.yml
+++ b/docs/security-template/.github/workflows/clippy.yml
@@ -1,0 +1,22 @@
+name: Clippy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  clippy:
+    name: cargo clippy -D warnings
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: ./.github/actions/setup-gtk4
+      # rust-toolchain.toml pins the channel + clippy component;
+      # rustup on the runner auto-installs on first cargo invocation.
+      - run: cargo clippy --all-targets --workspace -- -D warnings

--- a/docs/security-template/.github/workflows/codeql.yml
+++ b/docs/security-template/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run weekly on Monday at 06:00 UTC
+    - cron: '0 6 * * 1'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: CodeQL Analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: rust
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@256d634097be96e792d6764f9edaefc4320557b1 # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@256d634097be96e792d6764f9edaefc4320557b1 # v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/docs/security-template/.github/workflows/deny.yml
+++ b/docs/security-template/.github/workflows/deny.yml
@@ -1,0 +1,22 @@
+name: Cargo Deny
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run weekly on Monday at 06:00 UTC
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  deny:
+    name: License & Supply Chain Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2.0.15

--- a/docs/security-template/.github/workflows/fmt.yml
+++ b/docs/security-template/.github/workflows/fmt.yml
@@ -1,0 +1,21 @@
+name: Rustfmt
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  fmt:
+    name: cargo fmt --check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      # rust-toolchain.toml pins the channel + components (rustfmt, clippy);
+      # rustup on the runner auto-installs on first cargo invocation.
+      - run: cargo fmt --all -- --check

--- a/docs/security-template/.github/workflows/test.yml
+++ b/docs/security-template/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: cargo test --workspace
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: ./.github/actions/setup-gtk4
+      - run: cargo test --workspace

--- a/docs/security-template/.gitignore
+++ b/docs/security-template/.gitignore
@@ -1,0 +1,30 @@
+# Rust build artifacts
+target/
+**/*.rs.bk
+
+# rustc debug info (MSVC Windows)
+*.pdb
+
+# cargo-mutants output
+**/mutants.out*/
+
+# SonarQube scanner work dir
+.scannerwork/
+
+# Secrets — per-repo .env holds SONAR_TOKEN and any other credentials
+.env
+.env.example
+
+# SonarQube truststore (self-signed cert; regenerated per-machine)
+.truststore
+truststore.jks
+
+# Editor / IDE cruft
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store
+
+# NOTE: Cargo.lock is NOT ignored. It's committed for both the library
+# and binary crates so `cargo audit` runs reproducibly.

--- a/docs/security-template/.gitignore
+++ b/docs/security-template/.gitignore
@@ -11,9 +11,10 @@ target/
 # SonarQube scanner work dir
 .scannerwork/
 
-# Secrets — per-repo .env holds SONAR_TOKEN and any other credentials
+# Secrets — per-repo .env holds SONAR_TOKEN and any other credentials.
+# `.env.example` is intentionally NOT ignored — commit a placeholder
+# template so contributors know which vars to set.
 .env
-.env.example
 
 # SonarQube truststore (self-signed cert; regenerated per-machine)
 .truststore

--- a/docs/security-template/CHECKLIST.md
+++ b/docs/security-template/CHECKLIST.md
@@ -1,0 +1,131 @@
+# Post-copy checklist
+
+Things that don't live in a copy-pasted file — manual GitHub / SonarQube setup each per-tool repo needs after the file-level scaffolding from `docs/security-template/` lands.
+
+Run top to bottom for each of `nwg-common`, `nwg-dock`, `nwg-drawer`, `nwg-notifications`.
+
+## 1. Substitute placeholders in the copied files
+
+```bash
+find . -type f -not -path "./target/*" -exec sed -i \
+  -e 's|${REPO_OWNER}|jasonherald|g' \
+  -e 's|${REPO_NAME}|<this-repo-name>|g' {} +
+
+# Confirm no placeholders remain
+grep -rE '\$\{REPO_(OWNER|NAME)\}' . --exclude-dir=target --exclude-dir=.git
+```
+
+- `SECURITY.md` — replace `${REPO_OWNER}` + `${REPO_NAME}`.
+- `sonar-project.properties` — replace `${REPO_NAME}` in `sonar.projectKey` and `sonar.projectName`.
+
+## 2. Customize `SECURITY.md` Scope section
+
+The template's Scope section lists behaviors across all four tools. Prune to what this specific repo does:
+
+- `nwg-common` — library only; point at the consuming binaries' SECURITY.md for behavioral scope.
+- `nwg-dock` / `nwg-drawer` — `.desktop` Exec execution + pin-file I/O + compositor IPC.
+- `nwg-notifications` — D-Bus server + compositor IPC for focus signals.
+
+## 3. Prune `.coderabbit.yaml` path_instructions
+
+The template copies every path instruction from the monorepo. Each per-tool repo should delete the ones that don't match files in the target tree:
+
+- `nwg-common` — keep `crates/nwg-common/**`, drop the binary-specific `crates/nwg-dock/...`, `crates/nwg-drawer/...`, `crates/nwg-notifications/...` entries.
+- `nwg-dock` — keep `crates/nwg-dock/**` (in the new repo this path collapses to `src/**`; rewrite the glob), drop the other crate-specific entries.
+- Same pattern for `nwg-drawer` and `nwg-notifications`.
+- All repos keep: `.github/workflows/*.y*ml`, `.github/actions/**/action.y*ml`, `Makefile`, `**/CHANGELOG.md`, `**/Cargo.toml`, and the general-rules block.
+
+## 4. SonarQube project (server-side)
+
+**Required before the first `make sonar` run.**
+
+1. Log into [sonar.aaru.network](https://sonar.aaru.network).
+2. Create a new project with `Project key = <this-repo-name>` (match `sonar.projectKey` in `sonar-project.properties`).
+3. Generate a project analysis token.
+4. Drop the token into the repo's `.env` as `SONAR_TOKEN=...` (gitignored — see `.gitignore`).
+5. Regenerate the truststore if using the self-signed cert (see user memory / existing scripts).
+6. Run `make sonar` locally to confirm the scanner connects and uploads results.
+
+## 5. CodeRabbit (GitHub App)
+
+CodeRabbit is installed at the GitHub App level but must be enabled **per-repo** in its app settings.
+
+1. Go to <https://app.coderabbit.ai/> → **Repositories**.
+2. Toggle the new repo on.
+3. First PR in the repo confirms the `.coderabbit.yaml` is being read — look for the summary comment.
+
+## 6. Collaborator access
+
+Add `@nwg-piotr` as a collaborator with the same access level they have on the monorepo:
+
+```bash
+gh api -X PUT \
+  /repos/jasonherald/<this-repo-name>/collaborators/nwg-piotr \
+  -f permission=write
+```
+
+Do this **before** the first substantive PR in the repo — @nwg-piotr is part of the review rotation, and waiting until after a few PRs are merged means they miss the context.
+
+## 7. Branch protection on `main`
+
+```bash
+gh api -X PUT \
+  /repos/jasonherald/<this-repo-name>/branches/main/protection \
+  --input - <<'JSON'
+{
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 0,
+    "require_code_owner_reviews": false,
+    "dismiss_stale_reviews": true
+  },
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "Rustfmt / cargo fmt --check",
+      "Clippy / cargo clippy -D warnings",
+      "Test / cargo test --workspace",
+      "Cargo Deny / License & Supply Chain Check",
+      "Security Audit / Dependency Audit",
+      "CodeQL / CodeQL Analysis"
+    ]
+  },
+  "required_conversation_resolution": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "enforce_admins": false,
+  "restrictions": null
+}
+JSON
+```
+
+Notes:
+- Status-check contexts above are the `name:` values from the workflow YAMLs. If a workflow name changes, the context must be updated here.
+- Required checks only appear as selectable in the UI **after** each workflow has run at least once on a PR or push — push an initial no-op PR to trigger first-run before calling this API.
+- `required_approving_review_count: 0` because solo maintenance; bump to `1` when a co-maintainer lands.
+
+## 8. `.env` seeding
+
+Each new repo needs its own `.env` for local SonarQube scans:
+
+```bash
+# from the new repo's root
+cat > .env <<'ENV'
+SONAR_TOKEN=<token from step 4>
+SONAR_HOST_URL=https://sonar.aaru.network
+ENV
+
+# verify gitignored
+git check-ignore .env
+```
+
+## 9. First CI run
+
+Open a trivial PR (typo fix, README touch) to confirm:
+
+- [ ] All six workflows run and pass (fmt / clippy / test / deny / audit / codeql).
+- [ ] CodeRabbit posts a review summary.
+- [ ] The PR cannot be merged without the status checks passing (branch-protection working).
+
+## 10. Final
+
+- [ ] Update the root-repo README's migration banner table to link to the new repo and its crates.io page (#88 tracks the banner; Phase 7 flips the monorepo to archive notice).

--- a/docs/security-template/README.md
+++ b/docs/security-template/README.md
@@ -1,0 +1,47 @@
+# `docs/security-template/` — copy-paste-ready per-repo scaffolding
+
+This directory contains the security + CI + review artifacts that every per-tool repo (`nwg-common` / `nwg-dock` / `nwg-drawer` / `nwg-notifications`) needs on day one. The Phase 1–4 extractions in epic #80 each copy this tree into the new repo, substitute placeholders, and commit.
+
+## What's here
+
+| File | Action on copy |
+|------|----------------|
+| `SECURITY.md` | **Substitute** `${REPO_OWNER}` + `${REPO_NAME}`. **Review** the Scope section — the default covers all four tools; prune to what the target repo actually does (see comment at the top of the file). |
+| `sonar-project.properties` | **Substitute** `${REPO_NAME}` in `sonar.projectKey` and `sonar.projectName`. Create the SonarQube project server-side before the first scan. |
+| `.coderabbit.yaml` | Copy verbatim. **Prune** the `path_instructions:` entries that reference files not present in the target repo (e.g. the compositor-specific instructions only belong in `nwg-common`; the UI-specific ones only in the matching binary repo). |
+| `deny.toml` | Copy verbatim. Binary repos can likely adopt as-is; the library repo may drop some `[bans.skip]` entries once the transitive dep graph shrinks. |
+| `rust-toolchain.toml` | Copy verbatim. Pins the Rust channel + `rustfmt` / `clippy` components so CI and local `make lint` both pick up the right toolchain automatically. |
+| `.gitignore` | Copy verbatim. Standard Rust ignores + `.env` + truststore + editor cruft. `Cargo.lock` is explicitly NOT ignored. |
+| `.github/workflows/*.yml` | Copy verbatim (audit / codeql / deny / fmt / clippy / test). Each new repo gets the full CI set — no backfilling later. |
+| `.github/actions/setup-gtk4/action.yml` | Copy verbatim **into binary repos that link GTK4** (dock, drawer, notifications). The library repo (`nwg-common`) doesn't need it since the library itself is compiler-checked without the GTK4 system libs on clippy/test runners. |
+
+After the file-level copy, follow [`CHECKLIST.md`](./CHECKLIST.md) for the manual GitHub-side steps (SonarQube project, CodeRabbit app enable, collaborator, branch protection, `.env` token).
+
+## Why verbatim
+
+Copying verbatim keeps the four repos drift-free. When a security control changes (new workflow, tightened deny.toml rule, updated rabbit config), the monorepo's copy here is the source of truth; a follow-up PR propagates the change to each per-tool repo by running `cp -r docs/security-template/… ../other-repo/…` from the monorepo checkout.
+
+This is explicitly **not** a cargo-generate template or a scripted generator — it's a directory tree plus a substitution checklist. Two reasons:
+
+1. **Inspection before commit.** A human sees every line that lands in each new repo; there's no hidden codegen.
+2. **Low tooling surface.** No generator install, no template-engine knowledge required. `cp` + `sed -i 's/${REPO_NAME}/nwg-dock/g'` is enough.
+
+## Dry-run substitution
+
+Before the first phase extraction, run through the substitution on a throwaway target to confirm the template produces a working config:
+
+```bash
+TARGET=/tmp/security-template-dryrun
+rm -rf "$TARGET" && mkdir -p "$TARGET"
+cp -r docs/security-template/. "$TARGET/"
+# strip template-only files
+rm "$TARGET/README.md" "$TARGET/CHECKLIST.md"
+# substitute placeholders
+find "$TARGET" -type f -exec sed -i \
+  -e 's|${REPO_OWNER}|jasonherald|g' \
+  -e 's|${REPO_NAME}|nwg-common|g' {} +
+# what ran
+grep -rE '\$\{REPO_(OWNER|NAME)\}' "$TARGET" && echo "FAIL: leftover placeholders" || echo "OK: no placeholders left"
+```
+
+If the final `grep` prints "OK", the substitution is complete.

--- a/docs/security-template/SECURITY.md
+++ b/docs/security-template/SECURITY.md
@@ -1,0 +1,82 @@
+# Security Policy
+
+<!--
+    TEMPLATE — this file is copied into each per-tool repo as part of
+    the Phase 1–4 extractions (#80). Before committing, replace:
+
+      ${REPO_OWNER}   e.g. jasonherald
+      ${REPO_NAME}    e.g. nwg-common / nwg-dock / nwg-drawer / nwg-notifications
+
+    Also review the "Scope" section below — the default lists every
+    user-visible behavior across the four tools; prune to just the
+    behaviors this specific repo is responsible for:
+
+      nwg-common         Library only — no runtime behavior of its own;
+                         scope inherits from whichever binary consumes it.
+                         Consider pointing the reader at the binaries'
+                         SECURITY.md for behavioral scope.
+      nwg-dock           Executes `.desktop` Exec commands via compositor;
+                         reads/writes pin state; compositor IPC.
+      nwg-drawer         Executes `.desktop` Exec commands via compositor;
+                         reads/writes pin state; compositor IPC.
+      nwg-notifications  Listens on D-Bus (org.freedesktop.Notifications);
+                         compositor IPC for window-focus signals.
+-->
+
+## Supported Versions
+
+Only the latest release on the `main` branch is supported with security updates. We do not backport fixes to older versions.
+
+| Branch | Supported |
+|--------|-----------|
+| `main` | Yes |
+| Other  | No  |
+
+## Reporting a Vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Use GitHub's private vulnerability reporting to submit a report:
+
+1. Go to the [Security tab](https://github.com/${REPO_OWNER}/${REPO_NAME}/security)
+2. Click **"Report a vulnerability"**
+3. Provide a description, steps to reproduce, and any relevant details
+
+### What to expect
+
+- **Acknowledgment** within 48 hours
+- **Assessment** of severity and impact within 1 week
+- **Fix or mitigation** as soon as practical, depending on severity
+- **Disclosure** 90 days after the fix is released, or immediately if the vulnerability is already public
+- Credit in the fix commit (unless you prefer to remain anonymous)
+
+## Security Scanning
+
+This project uses automated security scanning across multiple layers:
+
+| Tool | Integration | Coverage |
+|------|-------------|----------|
+| [CodeQL](https://codeql.github.com/) | GitHub Actions (PR + weekly) | Source-level OWASP analysis (command injection, path traversal, tainted data flows) |
+| [cargo-audit](https://rustsec.org/) | GitHub Actions (PR + weekly) | Known CVEs in Rust dependencies (RustSec advisory database) |
+| [cargo-deny](https://embarkstudios.github.io/cargo-deny/) | GitHub Actions (PR + weekly) | License compliance, duplicate crates, source restrictions |
+| [CodeRabbit](https://coderabbit.ai/) | GitHub App (PR review) | AI-assisted code review with OSV dependency scanning |
+| [SonarQube](https://www.sonarqube.org/) | External (pre-PR) | Code quality, cognitive complexity, code smells |
+
+## Scope
+
+This project runs as a user-space application on Wayland compositors (Hyprland, Sway). It:
+
+- Executes `.desktop` file `Exec=` commands via the compositor
+- Reads/writes pin state to `~/.cache/mac-dock-pinned`
+- Listens on D-Bus as a notification daemon (`org.freedesktop.Notifications`)
+- Communicates with the compositor via IPC sockets
+
+Vulnerabilities in any of these areas are in scope.
+
+### Out of scope
+
+- Bugs in the compositor itself (Hyprland, Sway) — report upstream
+- Denial of service via resource exhaustion (e.g. sending thousands of notifications)
+- Malicious `.desktop` files — these are user-installed and trusted by design
+- Social engineering or phishing
+- Issues requiring physical access to the machine

--- a/docs/security-template/deny.toml
+++ b/docs/security-template/deny.toml
@@ -29,6 +29,11 @@ allow = [
     "MPL-2.0",
     "Unicode-3.0",
     "Unlicense",
+    # Common permissive licenses that occasionally surface via C-binding
+    # and compression dep chains. Added preemptively so a routine
+    # `cargo update` doesn't break `cargo-deny` on an otherwise fine dep.
+    "BSD-3-Clause",
+    "Zlib",
 ]
 confidence-threshold = 0.8
 exceptions = []

--- a/docs/security-template/deny.toml
+++ b/docs/security-template/deny.toml
@@ -1,0 +1,70 @@
+# cargo-deny configuration
+# https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+]
+
+[output]
+feature-depth = 1
+
+# =============================================================================
+# Advisories — check for known vulnerabilities
+# =============================================================================
+[advisories]
+ignore = []
+
+# =============================================================================
+# Licenses — only allow known-good open source licenses
+# =============================================================================
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "ISC",
+    "CC0-1.0",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unlicense",
+]
+confidence-threshold = 0.8
+exceptions = []
+
+[licenses.private]
+ignore = false
+registries = []
+
+# =============================================================================
+# Bans — prevent unwanted or duplicate crates
+# =============================================================================
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+highlight = "all"
+workspace-default-features = "allow"
+external-default-features = "allow"
+allow = []
+deny = []
+# Transitive duplicates from env_logger (anstream 0.6) vs clap (anstream 1.0).
+# Both are latest versions — waiting on env_logger to adopt anstream 1.0.
+skip = [
+    { crate = "anstream@0.6", reason = "env_logger 0.11 depends on anstream 0.6, clap 4.6 uses 1.0" },
+    { crate = "anstyle-parse@0.2", reason = "transitive from anstream 0.6 vs 1.0 split" },
+]
+# toml_datetime split is deep in GTK4's build dependency tree (system-deps → toml
+# vs proc-macro-crate → toml_edit). No action possible from our side.
+skip-tree = [
+    { crate = "toml_datetime@0.7", reason = "GTK4 build dep (system-deps) uses older toml chain" },
+]
+
+# =============================================================================
+# Sources — only allow crates from crates.io
+# =============================================================================
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/docs/security-template/rust-toolchain.toml
+++ b/docs/security-template/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]

--- a/docs/security-template/sonar-project.properties
+++ b/docs/security-template/sonar-project.properties
@@ -1,0 +1,26 @@
+# SonarQube project configuration
+#
+# TEMPLATE — this file is copied into each per-tool repo as part of the
+# Phase 1–4 extractions (#80). Before committing, replace:
+#   ${REPO_NAME}    e.g. nwg-common / nwg-dock / nwg-drawer / nwg-notifications
+# The SonarQube project itself must be created server-side first
+# (see CHECKLIST.md in this template dir).
+
+sonar.projectKey=${REPO_NAME}
+sonar.projectName=${REPO_NAME}
+sonar.projectVersion=0.3.0
+
+# Source code location
+sonar.sources=crates
+
+# Rust source files
+sonar.inclusions=**/*.rs
+
+# Exclude non-source files
+sonar.exclusions=**/target/**,tests/fixtures/**,tests/integration/**
+
+# Test file pattern
+sonar.test.inclusions=**/*test*.rs,**/tests/**
+
+# Encoding
+sonar.sourceEncoding=UTF-8

--- a/docs/security-template/sonar-project.properties
+++ b/docs/security-template/sonar-project.properties
@@ -13,14 +13,21 @@ sonar.projectVersion=0.3.0
 # Source code location
 sonar.sources=crates
 
+# Test sources must be set BEFORE sonar.test.inclusions — the inclusion
+# pattern filters files within this scope. Leaving it undefined silently
+# produces incomplete test classification.
+sonar.tests=crates
+
 # Rust source files
 sonar.inclusions=**/*.rs
 
 # Exclude non-source files
-sonar.exclusions=**/target/**,tests/fixtures/**,tests/integration/**
+sonar.exclusions=**/target/**
 
-# Test file pattern
-sonar.test.inclusions=**/*test*.rs,**/tests/**
+# Test file pattern — any file under a tests/ directory at any depth.
+# (Our codebase uses inline `#[cfg(test)] mod tests` at the bottom of
+# each .rs file; separate integration tests live under `crates/*/tests/`.)
+sonar.test.inclusions=**/tests/**
 
 # Encoding
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
Assembles the per-repo scaffolding Phase 1–4 extractions each need into one copy-paste-ready tree under `docs/security-template/`. With #119 landed, this template captures the **full** CI set (fmt / clippy / test + the pre-existing audit / deny / codeql) plus the composite action — every new repo starts with the same posture, no backfill later.

## What's in the template (15 files)

| File | Placeholder substitution? |
|------|--------------------------|
| `SECURITY.md` | `${REPO_OWNER}` + `${REPO_NAME}`; Scope section also needs per-repo pruning (inline comment explains what each repo's scope should cover) |
| `sonar-project.properties` | `${REPO_NAME}` in `sonar.projectKey` and `sonar.projectName` |
| `.coderabbit.yaml` | Verbatim. Per-repo: prune `path_instructions:` entries that don't match the target tree |
| `deny.toml` | Verbatim |
| `rust-toolchain.toml` | Verbatim |
| `.gitignore` | Verbatim. Rust ignores + `.env` + truststore + editor cruft; `Cargo.lock` explicitly not ignored |
| `.github/workflows/*.yml` | Verbatim — all six (audit/codeql/deny/fmt/clippy/test) |
| `.github/actions/setup-gtk4/action.yml` | Verbatim, for binary repos only (library doesn't link GTK4 on CI) |

Plus two guidance files (stay in the template, don't get copied out):
- `docs/security-template/README.md` — what's in each file, what to substitute vs. prune, + a dry-run one-liner to verify substitution.
- `docs/security-template/CHECKLIST.md` — 10-step manual GitHub-side sequence with exact `gh api` invocations for collaborator-add and branch-protection.

## Validation
Ran the README's dry-run against `/tmp/security-template-dryrun`:

```
$ find /tmp/security-template-dryrun -type f -exec sed -i \
    -e 's|${REPO_OWNER}|jasonherald|g' -e 's|${REPO_NAME}|nwg-common|g' {} +
$ grep -rE '\$\{REPO_(OWNER|NAME)\}' /tmp/security-template-dryrun && echo FAIL || echo OK
OK — no placeholders left
```

All 13 copied files substitute cleanly.

## Non-impact
- No repo-root file touched; CI behavior identical to pre-PR.
- `.github/workflows/` under `docs/security-template/` is intentionally nested — GitHub Actions only scans the top-level `.github/workflows/`, so these templates don't double-run.

## Test plan
- [x] Dry-run substitution produces zero leftover placeholders
- [x] Template tree structure valid (find + ls cross-check)
- [x] `cargo fmt --all -- --check` clean
- [ ] CI + CodeRabbit review of the PR itself
- [ ] Phase 1 (#91) copies the template into `jasonherald/nwg-common` — first real exercise

Closes #89.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added comprehensive security audit infra: CI workflows (audit, clippy, codeql, deny, fmt, test), linters/scanners, SonarQube configs, and a GTK4 setup action; updated license allowlist and gitignore.
* **Documentation**
  * Added security template docs, checklist, SECURITY.md, README, example env, and SonarQube/deny/toolchain templates for repo onboarding and review automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->