### PR TITLE
Draft per-repo README + CLAUDE.md templates (#113)

### DIFF
--- a/docs/readme-drafts/CLAUDE-nwg-common.md
+++ b/docs/readme-drafts/CLAUDE-nwg-common.md
@@ -24,7 +24,7 @@ make lint                     # Full check: fmt + clippy + test + deny + audit
 
 ## What lives where
 
-```
+```text
 crates/nwg-common/ (or src/ post-extraction)
 ├── compositor/       # Compositor trait + Hyprland/Sway/null backends
 ├── config/

--- a/docs/readme-drafts/CLAUDE-nwg-common.md
+++ b/docs/readme-drafts/CLAUDE-nwg-common.md
@@ -1,0 +1,105 @@
+# CLAUDE.md — nwg-common
+
+## What is this?
+
+The shared library behind the mac-doc-hyprland Rust port — compositor-neutral IPC abstraction, `.desktop` parsing, CSS loading, pin-file management, layer-shell helpers, and the various bits of system plumbing shared by [`nwg-dock`](https://github.com/jasonherald/nwg-dock), [`nwg-drawer`](https://github.com/jasonherald/nwg-drawer), and [`nwg-notifications`](https://github.com/jasonherald/nwg-notifications).
+
+Pre-split (before v0.3.0) this lived as `nwg-dock-common` inside the [mac-doc-hyprland](https://github.com/jasonherald/mac-doc-hyprland) monorepo; that repo's git log has the full pre-0.3.0 history.
+
+## Build & test
+
+```bash
+cargo build                   # Debug build
+cargo build --release         # Release build
+cargo test                    # Run unit tests
+cargo clippy --all-targets    # Lint (should be zero warnings)
+cargo fmt --all               # Format
+cargo deny check              # License, advisory, ban, source checks
+cargo audit                   # Dependency CVE scan
+make test                     # Unit tests + clippy
+make lint                     # Full check: fmt + clippy + test + deny + audit
+```
+
+`make test-integration` is primarily about exercising the Sway backend against a headless Sway instance — requires `sway` and `foot` installed. Per [tests/integration/CLASSIFICATION.md](https://github.com/jasonherald/mac-doc-hyprland/blob/main/tests/integration/CLASSIFICATION.md) in the monorepo, this crate owns the Sway IPC tests + Sway window-management tests.
+
+## What lives where
+
+```
+crates/nwg-common/ (or src/ post-extraction)
+├── compositor/       # Compositor trait + Hyprland/Sway/null backends
+├── config/
+│   ├── css.rs        # GTK4 CSS provider loading + hot-reload + @import graph
+│   ├── flags.rs      # normalize_legacy_flags — pre-clap -foo → --foo
+│   └── paths.rs      # XDG cache/config/data resolution
+├── desktop/
+│   ├── categories.rs # FreeDesktop main-category assignment
+│   ├── dirs.rs       # XDG_DATA_DIRS enumeration
+│   ├── entry.rs      # .desktop file parser (DesktopEntry)
+│   ├── icons.rs      # icon + display-name resolution
+│   └── preferred_apps.rs
+├── hyprland/         # Private — Hyprland IPC types/events (compositor::hyprland wraps this)
+├── launch.rs         # launch / launch_desktop_entry / launch_via_compositor + child-reaper
+├── layer_shell.rs    # create_fullscreen_backdrops per monitor
+├── pinning.rs        # ~/.cache/mac-dock-pinned read/write (atomic, case-insensitive)
+├── process.rs        # handle_dump_args for --dump-args <pid> flow
+├── signals.rs        # RT signal handling (SIGRTMIN+N), WindowCommand mapping
+├── singleton.rs      # Per-user lock file with stale-PID recovery
+├── error.rs          # Private — DockError + Result re-exported at crate root
+└── lib.rs
+```
+
+## Conventions
+
+- **`#![warn(missing_docs)]` on the crate root** — every `pub` item has a rustdoc comment. `cargo doc --no-deps -p nwg-common` runs warning-free; `cargo rustdoc -p nwg-common -- -D missing-docs` succeeds.
+- **Public surface is sealed** — `hyprland::*`, `error::*`, `compositor::{hyprland, sway, null, traits, types}` are all private at the module level. Only items that library consumers legitimately need are exposed. `DockError` and `Result` are re-exported at crate root (`nwg_common::DockError`, `nwg_common::Result<T>`).
+- **Compositor trait owns all WM IPC** — no direct hyprland or sway calls leak to consumers. Binaries use `init_or_exit` or `init_or_null` and only touch the trait from then on.
+- **Unsafe only in signals.rs** — required for RT signal handling via raw libc (`nix::Signal` doesn't cover `SIGRTMIN+N`). Every unsafe block has a SAFETY comment explaining invariants; return codes from `sigemptyset`/`sigaddset`/`pthread_sigmask` are checked.
+- **Tests** — `#[cfg(test)] mod tests` at the bottom of each file, test behavior not implementation.
+- **No magic numbers** — every numeric literal has a named constant or clear inline comment.
+- **Error handling** — log errors, never silently discard with `let _ =`.
+
+## Stability contract
+
+0.x crate. Breaking changes ship as **minor** bumps (`0.3 → 0.4`) per crates.io convention; additive changes are **patch** or **minor** depending on scope. 1.0.0 is a deliberate decision for later, once the three consumer binaries have soaked the API.
+
+Binaries should pin `nwg-common = "0.3"` (or whatever minor is current) so patch bumps flow automatically while minor bumps are opted into.
+
+## Signal assignments
+
+Shared contract across the three consumer binaries (mutations here need coordinated releases):
+
+| Signal | Value | Target | Action |
+|--------|-------|--------|--------|
+| SIGRTMIN+1 | ~35 | Dock/Drawer | Toggle visibility |
+| SIGRTMIN+2 | ~36 | Dock/Drawer | Show |
+| SIGRTMIN+3 | ~37 | Dock/Drawer | Hide |
+| SIGRTMIN+4 | ~38 | Notifications | Toggle panel |
+| SIGRTMIN+5 | ~39 | Notifications | Toggle DND |
+| SIGRTMIN+6 | ~40 | Notifications | Show DND menu |
+| SIGRTMIN+11 | ~45 | Waybar | Refresh notification module |
+
+Values are approximate because glibc and musl reserve different numbers of NPTL slots — `signals::sigrtmin()` queries `libc::SIGRTMIN()` at runtime for portability.
+
+## Shared pin file
+
+`~/.cache/mac-dock-pinned` — one desktop ID per line, no `.desktop` suffix. `pinning::{save_pinned, load_pinned, pin_item, unpin_item, is_pinned}` are the public entry points. Writes are atomic (temp file + rename) to prevent corruption on crash.
+
+## Compositor abstraction
+
+All compositor IPC goes through the `Compositor` trait in `compositor/traits.rs`. Auto-detection checks `HYPRLAND_INSTANCE_SIGNATURE` and `SWAYSOCK` env vars.
+
+- `init_or_exit(Option<WmOverride>) -> Box<dyn Compositor>` — dock/notifications (hard-require a compositor).
+- `init_or_null(Option<WmOverride>) -> Box<dyn Compositor>` — drawer (graceful fallback on Niri/river/Openbox via `NullCompositor`).
+
+Key types (all public, all documented): `WmClient`, `WmMonitor`, `WmWorkspace`, `WmEvent`, `WmOverride`.
+
+Private backends in `compositor/`:
+- `hyprland.rs` — wraps the (private) top-level `hyprland::ipc`, converts Hyprland types to `Wm*` types.
+- `sway.rs` — i3-ipc-based Sway backend with magic-byte + payload-size validation.
+- `null.rs` — no-op fallback; most methods return `DockError::NoCompositorDetected`.
+
+## See also
+
+- `CHANGELOG.md` — user-visible changes per release, Keep-a-Changelog format.
+- `README.md` — public-facing library docs + stability contract + pre-split pointer.
+- Parent monorepo archive: [jasonherald/mac-doc-hyprland](https://github.com/jasonherald/mac-doc-hyprland) (pre-0.3.0 history).

--- a/docs/readme-drafts/CLAUDE-nwg-dock.md
+++ b/docs/readme-drafts/CLAUDE-nwg-dock.md
@@ -106,7 +106,7 @@ The dock rebuild function needs to pass itself to buttons (for pin/unpin rebuild
 
 ### Cursor-based autohide
 
-Uses compositor IPC cursor position polling (Hyprland `j/cursorpos`). Cached monitor list refreshed every ~10s. See `ui/hotspot.rs`. On Sway (no cursor-position IPC) this falls back to GTK hotspot windows.
+Uses compositor IPC cursor position polling (Hyprland `j/cursorpos`). Cached monitor list refreshed every ~10s. The implementation lives under `ui/hotspot/` — `mod.rs` coordinates, `cursor_poller.rs` owns the Hyprland path, `hotspot_windows.rs` owns the Sway fallback (GTK hotspot surfaces, since Sway has no cursor-position IPC).
 
 ### Drag-to-reorder
 

--- a/docs/readme-drafts/CLAUDE-nwg-dock.md
+++ b/docs/readme-drafts/CLAUDE-nwg-dock.md
@@ -1,0 +1,129 @@
+# CLAUDE.md — nwg-dock
+
+## What is this?
+
+A macOS-style dock for Hyprland and Sway, written in Rust. Renamed from `nwg-dock-hyprland` at v0.3.0 because the Rust port supports both compositors through one binary (Compositor trait + runtime `--wm` auto-detection), so the compositor-specific name stopped fitting. A `nwg-dock-hyprland` symlink alias is dropped by `make install` so existing autostart lines keep working.
+
+Consumes [`nwg-common`](https://github.com/jasonherald/nwg-common) for compositor IPC, `.desktop` parsing, pin-file management, CSS hot-reload, and signal plumbing.
+
+Pre-split (before v0.3.0) this lived inside the [mac-doc-hyprland](https://github.com/jasonherald/mac-doc-hyprland) monorepo at `crates/nwg-dock/` with `[[bin]].name = "nwg-dock-hyprland"`; that repo's git log has the full pre-0.3.0 history.
+
+## Build & test
+
+```bash
+cargo build                   # Debug build
+cargo build --release         # Release build
+cargo test                    # Unit tests
+cargo clippy --all-targets    # Lint (should be zero warnings)
+cargo fmt --all               # Format
+make test                     # Unit tests + clippy
+make test-integration         # Headless Sway integration tests (requires sway, foot)
+make lint                     # Full check: fmt + clippy + test + deny + audit
+```
+
+Per [tests/integration/CLASSIFICATION.md](https://github.com/jasonherald/mac-doc-hyprland/blob/main/tests/integration/CLASSIFICATION.md) in the monorepo, this repo owns the dock-binary-launch smoke test plus the shared Sway bootstrap scaffolding; the Sway IPC + window-management tests live in `nwg-common`.
+
+## Install (dev workflow)
+
+**Use the no-sudo invocation when iterating locally from a clone.** The Makefile's default target is system-wide (`sudo make install` → `/usr/local/bin`); during development you almost certainly want:
+
+```bash
+make install PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin
+```
+
+This drops `nwg-dock` in `~/.cargo/bin/` without touching `/usr/local`. Rerun after code changes; `make upgrade` rebuilds + reinstalls + restarts in one shot. See the README for the end-user install matrix (default / no-sudo / distro-parity).
+
+## Run locally
+
+```bash
+# Basic — auto-hide, 48px icons, translucent
+nwg-dock -d -i 48 --mb 10 --hide-timeout 400
+
+# With launch animation + drawer integration
+nwg-dock -d -i 48 --mb 10 --hide-timeout 400 --launch-animation -c "nwg-drawer --pb-auto"
+
+# Force Sway backend (auto-detection is usually enough)
+nwg-dock --wm sway
+
+# Legacy name — symlink, same behavior
+nwg-dock-hyprland -d -i 48 --mb 10
+```
+
+## What lives where
+
+```
+src/  (or crates/nwg-dock/src/ in the monorepo)
+├── main.rs             # Thin coordinator (~130 lines)
+├── config.rs           # clap CLI with Position / Alignment / Layer enums
+├── context.rs          # DockContext bundles shared refs + compositor
+├── dock_windows.rs     # Per-monitor window creation
+├── rebuild.rs          # Self-referential rebuild function (Weak to avoid Rc cycle)
+├── state.rs            # DockState bundle
+├── listeners.rs        # Pin watcher, signal poller, autohide
+├── events.rs           # Compositor event stream → smart rebuild
+└── ui/
+    ├── window.rs, dock_box.rs, buttons.rs, menus.rs
+    ├── hotspot/        # Cursor poller (Hyprland) / GTK hotspot (Sway fallback)
+    ├── drag.rs         # GTK4 DragSource + single DropTarget
+    ├── dock_menu.rs    # Right-click dock background menu
+    └── css.rs          # CSS loading + hot-reload via nwg_common::config::css
+
+data/ (or data/nwg-dock-hyprland/ in the monorepo)
+├── style.css          # Default CSS shipped to /usr/local/share/nwg-dock/
+└── images/            # Icons shipped with the dock
+```
+
+## Conventions
+
+- **Enums over strings** — Position, Alignment, Layer are all `clap::ValueEnum` or repr enums.
+- **Named constants** — all UI dimensions in `ui/constants.rs`.
+- **DockContext** — bundles config/state/data_home/pinned_file/rebuild/compositor for clean function signatures; never pass 7+ individual refs.
+- **Compositor trait only** — all WM IPC goes through `nwg_common::compositor::Compositor`. No direct hyprland or sway calls anywhere in this crate.
+- **No `#[allow(dead_code)]`** — all code is used.
+- **No magic numbers** — every numeric literal has a named constant or clear inline comment.
+- **Error handling** — log errors, never silently discard with `let _ =`.
+- **Unsafe** — none in this crate; the dock relies on `nwg_common::signals` for the RT-signal unsafe bits.
+- **Tests** — `#[cfg(test)] mod tests` at bottom of file, test behavior not implementation.
+
+## Key patterns
+
+### GTK4 button layout
+
+GTK4 has no `set_image`/`set_image_position`. Use a vertical Box:
+
+```rust
+let vbox = Box::new(Orientation::Vertical, 4);
+vbox.append(&image);
+vbox.append(&label);
+button.set_child(Some(&vbox));
+```
+
+Shared helper: `ui::widgets::app_icon_button()`.
+
+### Self-referential rebuild
+
+The dock rebuild function needs to pass itself to buttons (for pin/unpin rebuild). Uses `Weak` reference to avoid Rc cycle. See `rebuild.rs`.
+
+### Cursor-based autohide
+
+Uses compositor IPC cursor position polling (Hyprland `j/cursorpos`). Cached monitor list refreshed every ~10s. See `ui/hotspot.rs`. On Sway (no cursor-position IPC) this falls back to GTK hotspot windows.
+
+### Drag-to-reorder
+
+GTK4 DragSource on each pinned button (including running apps), single DropTarget on the dock box. Cursor poller tracks `drag_outside_dock` state for unpin-by-drag-off. Preview icon cached to avoid glycin reentrancy crashes. Rebuilds deferred via `idle_add_local_once`. Lock state persisted in `~/.cache/nwg-dock-locked`. See `ui/drag.rs` and `ui/dock_menu.rs`.
+
+## Shared pin file
+
+`~/.cache/mac-dock-pinned` (contract defined in `nwg_common::pinning`). Shared with the drawer; changes detected via inotify for instant sync. Right-click a dock icon → Pin/Unpin. Drag an icon off the dock to unpin.
+
+## CSS path
+
+`~/.config/nwg-dock-hyprland/style.css` — path kept for continuity with the Go predecessor. Live hot-reload via `nwg_common::config::css::watch_css`; edit the file and the dock picks up changes without restart. `@import` graph walked to 32 levels, cycles detected.
+
+## See also
+
+- `CHANGELOG.md` — user-visible changes per release, Keep-a-Changelog format.
+- `README.md` — public-facing docs + install matrix + migration-from-`nwg-dock-hyprland` section.
+- [`nwg-common`](https://github.com/jasonherald/nwg-common) — shared library (Compositor trait, pinning, CSS, signals, etc.).
+- [`nwg-drawer`](https://github.com/jasonherald/nwg-drawer) — launcher the dock delegates to via `-c`.
+- Parent monorepo archive: [jasonherald/mac-doc-hyprland](https://github.com/jasonherald/mac-doc-hyprland).

--- a/docs/readme-drafts/CLAUDE-nwg-dock.md
+++ b/docs/readme-drafts/CLAUDE-nwg-dock.md
@@ -2,7 +2,7 @@
 
 ## What is this?
 
-A macOS-style dock for Hyprland and Sway, written in Rust. Renamed from `nwg-dock-hyprland` at v0.3.0 because the Rust port supports both compositors through one binary (Compositor trait + runtime `--wm` auto-detection), so the compositor-specific name stopped fitting. A `nwg-dock-hyprland` symlink alias is dropped by `make install` so existing autostart lines keep working.
+A macOS-style dock for Hyprland and Sway, written in Rust. Renamed from `nwg-dock-hyprland` at v0.3.0 because the Rust port supports both compositors through one binary (Compositor trait + runtime `--wm` auto-detection), so the compositor-specific name stopped fitting. A `nwg-dock-hyprland` symlink alias is installed by `make install` so existing autostart lines keep working.
 
 Consumes [`nwg-common`](https://github.com/jasonherald/nwg-common) for compositor IPC, `.desktop` parsing, pin-file management, CSS hot-reload, and signal plumbing.
 

--- a/docs/readme-drafts/CLAUDE-nwg-dock.md
+++ b/docs/readme-drafts/CLAUDE-nwg-dock.md
@@ -51,7 +51,7 @@ nwg-dock-hyprland -d -i 48 --mb 10
 
 ## What lives where
 
-```
+```text
 src/  (or crates/nwg-dock/src/ in the monorepo)
 ├── main.rs             # Thin coordinator (~130 lines)
 ├── config.rs           # clap CLI with Position / Alignment / Layer enums

--- a/docs/readme-drafts/CLAUDE-nwg-drawer.md
+++ b/docs/readme-drafts/CLAUDE-nwg-drawer.md
@@ -54,7 +54,7 @@ nwg-drawer --wm uwsm
 
 ## What lives where
 
-```
+```text
 src/
 ├── main.rs            # Coordinator (~185 lines)
 ├── config.rs          # clap CLI with CloseButton enum

--- a/docs/readme-drafts/CLAUDE-nwg-drawer.md
+++ b/docs/readme-drafts/CLAUDE-nwg-drawer.md
@@ -1,0 +1,114 @@
+# CLAUDE.md — nwg-drawer
+
+## What is this?
+
+A Launchpad-style application launcher + file search overlay for Hyprland, Sway, and any Wayland compositor with layer-shell support. Written in Rust, ported from [nwg-piotr/nwg-drawer](https://github.com/nwg-piotr/nwg-drawer) (Go).
+
+Consumes [`nwg-common`](https://github.com/jasonherald/nwg-common) for compositor IPC, `.desktop` parsing, pin-file management, CSS hot-reload, and launch plumbing.
+
+Pre-split (before v0.3.0) this lived inside the [mac-doc-hyprland](https://github.com/jasonherald/mac-doc-hyprland) monorepo at `crates/nwg-drawer/`.
+
+## Build & test
+
+```bash
+cargo build                   # Debug build
+cargo build --release         # Release build
+cargo test                    # Unit tests
+cargo clippy --all-targets    # Lint (should be zero warnings)
+cargo fmt --all               # Format
+make test                     # Unit tests + clippy
+make lint                     # Full check: fmt + clippy + test + deny + audit
+```
+
+`make test-integration` exists as a scaffold (bootstraps headless Sway) but this crate has **no integration tests today**. The drawer is on-demand (spawn, show, exit on selection/focus loss), which makes integration testing awkward. Room for future additions; see [tests/integration/CLASSIFICATION.md](https://github.com/jasonherald/mac-doc-hyprland/blob/main/tests/integration/CLASSIFICATION.md) in the monorepo for classification rules.
+
+## Install (dev workflow)
+
+**Use the no-sudo invocation when iterating locally.** Default `make install` is system-wide:
+
+```bash
+make install PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin
+```
+
+See the README for the full install matrix (default / no-sudo / distro-parity / cargo install).
+
+## Run locally
+
+```bash
+# Basic with auto-detected power bar
+nwg-drawer --pb-auto
+
+# Resident mode (stays in memory, toggle with signals)
+nwg-drawer -r --pb-auto
+
+# Force Sway backend (auto-detection is usually enough)
+nwg-drawer --wm sway
+
+# Force the null (compositor-less) fallback
+nwg-drawer --wm uwsm
+```
+
+## What lives where
+
+```
+src/
+├── main.rs            # Coordinator (~185 lines)
+├── config.rs          # clap CLI with CloseButton enum
+├── state.rs           # DrawerState + AppRegistry sub-struct
+├── desktop_loader.rs  # Scans .desktop files, multi-category assignment
+├── listeners.rs       # Keyboard, focus detector, file watcher, signals
+└── ui/
+    ├── well_builder.rs   # WellContext (bundles 7+ params into one struct)
+    ├── search_handler.rs
+    ├── app_grid.rs, pinned.rs, file_search.rs
+    ├── widgets.rs
+    ├── math.rs           # exmex-based expression evaluator (see Conventions)
+    ├── power_bar.rs
+    ├── search.rs
+    └── window.rs
+
+assets/
+└── drawer.css         # Embedded default CSS via include_str!()
+```
+
+## Conventions
+
+- **Enums over strings** — CloseButton, etc. are `clap::ValueEnum` or repr enums.
+- **Named constants** — all UI dimensions in `ui/constants.rs`.
+- **`WellContext`** — the well/category/search builders take one `WellContext` struct, not 7+ individual params. Expanding a builder signature is a smell; add a field to the context instead.
+- **Compositor trait only** — all WM IPC goes through `nwg_common::compositor::Compositor`. The drawer uses `init_or_null` to fall back gracefully on Niri, river, Openbox, etc.
+- **Math evaluation uses `exmex`** — not `meval` (migrated in #64). Safe parser, no `eval`/shell. Custom operator factory adds `pi` / `π`, `%` modulo, and base-10 `log`. Scoped to pure arithmetic (no variables) so random search queries don't accidentally evaluate.
+- **Inline math results don't trap keyboard focus** — vbox/row/label stay non-focusable so arrow keys continue to navigate the grid.
+- **Pin/unpin operations roll back on save failure.**
+- **`launch_desktop_entry()`** — use the helper from `nwg_common::launch`, not inline strip/prepend/launch.
+- **No `#[allow(dead_code)]`, no magic numbers, log errors, tests at bottom of file.**
+
+## Key patterns
+
+### Capture-phase keyboard nav
+
+The drawer's arrow-key navigation uses a capture-phase event handler to bypass `FlowBox`'s default key bindings. See `listeners.rs`. Avoids intercepting type-to-search characters; only arrows/Enter/Escape are consumed.
+
+### Launcher command
+
+The drawer is typically spawned by the dock's launcher button (`nwg-dock -c "nwg-drawer --pb-auto"`). Resident mode (`-r`) keeps it in memory for faster subsequent opens; on-demand is the default.
+
+### Null-compositor fallback
+
+`init_or_null` returns a `NullCompositor` when neither Hyprland nor Sway is detected. Most compositor methods return `DockError::NoCompositorDetected`, but launches still work (direct spawn via `nwg_common::launch`). Useful for running the drawer on Niri, river, Openbox, etc.
+
+## Shared pin file
+
+`~/.cache/mac-dock-pinned` (contract defined in `nwg_common::pinning`). Shared with the dock; right-click an app → Pin. Changes picked up via `notify` crate for instant sync.
+
+## CSS path
+
+`~/.config/nwg-drawer/drawer.css` — live hot-reload via `nwg_common::config::css::watch_css`. `@import` graph walked to 32 levels, cycles detected.
+
+## See also
+
+- `CHANGELOG.md` — user-visible changes per release, Keep-a-Changelog format.
+- `README.md` — public-facing docs + install matrix + dock integration.
+- [`nwg-common`](https://github.com/jasonherald/nwg-common) — shared library.
+- [`nwg-dock`](https://github.com/jasonherald/nwg-dock) — dock that typically spawns the drawer via its launcher button.
+- Parent monorepo archive: [jasonherald/mac-doc-hyprland](https://github.com/jasonherald/mac-doc-hyprland).

--- a/docs/readme-drafts/CLAUDE-nwg-drawer.md
+++ b/docs/readme-drafts/CLAUDE-nwg-drawer.md
@@ -44,7 +44,11 @@ nwg-drawer -r --pb-auto
 # Force Sway backend (auto-detection is usually enough)
 nwg-drawer --wm sway
 
-# Force the null (compositor-less) fallback
+# Use uwsm launcher mode (auto-detects Hyprland or Sway from env).
+# Note: uwsm is a launch-wrapper mode, NOT a trigger for the null
+# fallback — detection still falls through to
+# HYPRLAND_INSTANCE_SIGNATURE / SWAYSOCK. The null backend kicks in
+# automatically when neither env var is set (Niri, river, Openbox).
 nwg-drawer --wm uwsm
 ```
 
@@ -56,13 +60,19 @@ src/
 ├── config.rs          # clap CLI with CloseButton enum
 ├── state.rs           # DrawerState + AppRegistry sub-struct
 ├── desktop_loader.rs  # Scans .desktop files, multi-category assignment
-├── listeners.rs       # Keyboard, focus detector, file watcher, signals
+├── listeners.rs       # Focus detector, file watcher, signal receiver
 └── ui/
+    ├── navigation.rs     # install_grid_nav — capture-phase arrow-key
+    │                     # traversal across FlowBox grids (app grid,
+    │                     # pinned row, categories). Uses Weak refs
+    │                     # to avoid widget ↔ controller cycles.
     ├── well_builder.rs   # WellContext (bundles 7+ params into one struct)
+    ├── well_context.rs   # The WellContext struct itself
     ├── search_handler.rs
     ├── app_grid.rs, pinned.rs, file_search.rs
     ├── widgets.rs
     ├── math.rs           # exmex-based expression evaluator (see Conventions)
+    ├── categories.rs
     ├── power_bar.rs
     ├── search.rs
     └── window.rs
@@ -87,7 +97,7 @@ assets/
 
 ### Capture-phase keyboard nav
 
-The drawer's arrow-key navigation uses a capture-phase event handler to bypass `FlowBox`'s default key bindings. See `listeners.rs`. Avoids intercepting type-to-search characters; only arrows/Enter/Escape are consumed.
+The drawer's arrow-key navigation uses a capture-phase event handler to bypass `FlowBox`'s default key bindings. See `ui/navigation.rs` (`install_grid_nav`). Avoids intercepting type-to-search characters; only arrows/Enter/Escape are consumed. Up/down edges can jump to adjacent FlowBox grids (app grid → pinned row → categories) via the `up_target` / `down_target` parameters.
 
 ### Launcher command
 

--- a/docs/readme-drafts/CLAUDE-nwg-notifications.md
+++ b/docs/readme-drafts/CLAUDE-nwg-notifications.md
@@ -4,7 +4,7 @@
 
 A D-Bus notification daemon + notification center for Hyprland and Sway, written in Rust. Claims `org.freedesktop.Notifications`, shows popup toasts, and ships a slide-out history panel with Do-Not-Disturb and waybar integration. Replaces mako in the mac-doc-hyprland stack; runs standalone.
 
-Consumes [`nwg-common`](https://github.com/jasonherald/nwg-common) for compositor IPC, `.desktop` parsing, icon resolution, signal plumbing, and layer-shell backdrops.
+Consumes [`nwg-common`](https://github.com/jasonherald/nwg-common) for compositor IPC, `.desktop` parsing, signal plumbing, and layer-shell backdrops. Notification-specific icon helpers (`resolve_popup_icon` / `resolve_theme_icon`) live locally in `src/ui/icons.rs` — they're pixbuf / theme-variant helpers specific to the popup and panel rendering path, not shared with dock/drawer.
 
 Pre-split (before v0.3.0) this lived inside the [mac-doc-hyprland](https://github.com/jasonherald/mac-doc-hyprland) monorepo at `crates/nwg-notifications/`.
 
@@ -122,6 +122,6 @@ The daemon writes its current state to `$XDG_RUNTIME_DIR/mac-notifications-statu
 
 - `CHANGELOG.md` — user-visible changes per release, Keep-a-Changelog format.
 - `README.md` — public-facing docs + install matrix + waybar config + D-Bus service file setup.
-- [`nwg-common`](https://github.com/jasonherald/nwg-common) — shared library (Compositor trait for focus-on-click, icons, signals, layer-shell backdrops).
+- [`nwg-common`](https://github.com/jasonherald/nwg-common) — shared library (Compositor trait for focus-on-click, `.desktop` metadata lookup via `desktop::icons::get_exec`, signals, layer-shell backdrops). Pixbuf + theme-variant icon rendering stays local — see `src/ui/icons.rs`.
 - Parent monorepo archive: [jasonherald/mac-doc-hyprland](https://github.com/jasonherald/mac-doc-hyprland).
 - [Desktop Notifications Specification](https://specifications.freedesktop.org/notification-spec/latest/) — canonical reference for D-Bus protocol compliance.

--- a/docs/readme-drafts/CLAUDE-nwg-notifications.md
+++ b/docs/readme-drafts/CLAUDE-nwg-notifications.md
@@ -1,0 +1,127 @@
+# CLAUDE.md — nwg-notifications
+
+## What is this?
+
+A D-Bus notification daemon + notification center for Hyprland and Sway, written in Rust. Claims `org.freedesktop.Notifications`, shows popup toasts, and ships a slide-out history panel with Do-Not-Disturb and waybar integration. Replaces mako in the mac-doc-hyprland stack; runs standalone.
+
+Consumes [`nwg-common`](https://github.com/jasonherald/nwg-common) for compositor IPC, `.desktop` parsing, icon resolution, signal plumbing, and layer-shell backdrops.
+
+Pre-split (before v0.3.0) this lived inside the [mac-doc-hyprland](https://github.com/jasonherald/mac-doc-hyprland) monorepo at `crates/nwg-notifications/`.
+
+## Build & test
+
+```bash
+cargo build                   # Debug build
+cargo build --release         # Release build
+cargo test                    # Unit tests
+cargo clippy --all-targets    # Lint (should be zero warnings)
+cargo fmt --all               # Format
+make test                     # Unit tests + clippy
+make test-integration         # Headless Sway integration tests (requires sway)
+make lint                     # Full check: fmt + clippy + test + deny + audit
+```
+
+Per [tests/integration/CLASSIFICATION.md](https://github.com/jasonherald/mac-doc-hyprland/blob/main/tests/integration/CLASSIFICATION.md) in the monorepo, this repo owns daemon-launch + signal-resilience tests (SIGRTMIN+4 panel toggle, SIGRTMIN+5 DND toggle). The D-Bus `notify-send` path isn't exercised in integration today because the test harness uses an isolated D-Bus to avoid interfering with the real desktop session.
+
+## Install (dev workflow)
+
+**Use the no-sudo invocation when iterating locally.** Default `make install` is system-wide:
+
+```bash
+make install PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin
+make install-dbus
+```
+
+`make install-dbus` is ALWAYS user-scope (no sudo; drops the service file into `~/.local/share/dbus-1/services/`) regardless of `PREFIX`. D-Bus user services are per-user by convention, and installing the service file system-wide would break auto-activation for other users.
+
+See the README for the full install matrix.
+
+## Run locally
+
+```bash
+# With history persistence
+nwg-notifications --persist
+
+# Force Sway backend (auto-detection is usually enough)
+nwg-notifications --wm sway --persist
+```
+
+The daemon auto-starts the first time any app calls `org.freedesktop.Notifications` once the D-Bus service file is registered — explicit `exec-once` isn't strictly required, but makes the first toast faster.
+
+## What lives where
+
+```
+src/
+├── main.rs            # Coordinator (~160 lines)
+├── config.rs          # clap CLI with PopupPosition enum
+├── notification.rs    # Notification struct, Urgency enum, action parsing
+├── state.rs           # NotificationState: history, groups, DND, dnd_expires
+├── dbus.rs            # gio D-Bus server (org.freedesktop.Notifications)
+├── listeners.rs       # Signal poller (panel toggle, DND toggle, DND menu)
+├── persistence.rs     # Save/load history as JSON
+├── waybar.rs          # Status file + waybar signal (SIGRTMIN+11)
+└── ui/
+    ├── popup.rs              # Auto-dismissing toasts
+    ├── panel.rs, panel_content.rs  # History panel
+    ├── notification_row.rs
+    ├── dnd_menu.rs           # DND duration picker
+    ├── icons.rs              # Icon resolution (pixbuf + theme variants)
+    ├── window.rs, css.rs, constants.rs
+
+assets/
+└── notifications.css  # Embedded default CSS via include_str!()
+
+data/
+└── org.freedesktop.Notifications.service  # D-Bus service file (installed by make install-dbus)
+```
+
+## Conventions
+
+- **Enums over strings** — PopupPosition, Urgency are `clap::ValueEnum` or repr enums.
+- **Named constants** — all UI dimensions in `ui/constants.rs`.
+- **D-Bus server uses `gio::bus_own_name`** — no async bridge; runs directly on the glib main loop. D-Bus connection stored in `NotificationState` for emitting `ActionInvoked` signals when action buttons are clicked.
+- **Backdrop windows have non-zero opacity** — `rgba(0,0,0,0.01)` minimum. Without that, the compositor doesn't deliver pointer events to the layer-shell surface; clicks pass through to whatever's underneath.
+- **`on_state_change` callback** — a shared `Rc<dyn Fn()>` threaded through panel, popup, listeners, and D-Bus callbacks. Fires on any state mutation to save history + update waybar. Avoids polling or observer patterns.
+- **No `#[allow(dead_code)]`, no magic numbers, log errors, tests at bottom of file.**
+- **Protocol compliance** — every change to the D-Bus surface must be checked against the [Desktop Notifications Specification](https://specifications.freedesktop.org/notification-spec/latest/). The spec is small but strict.
+
+## Key patterns
+
+### D-Bus notification server
+
+`gio::bus_own_name` + `register_object` on the session bus. D-Bus method calls are dispatched from a vtable to handler functions in `dbus.rs`. `ActionInvoked` signals go out via the stored `BusConnection` when users click action buttons.
+
+### Deep-linking
+
+When a notification click is acknowledged and the sending app has a known .desktop entry, the daemon focuses the app via compositor IPC (`Compositor::focus_window`) and then falls through to the desktop entry's Exec for "open the specific item" behavior.
+
+### Auto-dismiss and CloseNotification
+
+Apps like Slack emit `CloseNotification` when the user reads the message in-app. The daemon matches by notification ID and removes the popup + history entry.
+
+### Click-outside-to-close
+
+Panel and DND menu use a transparent backdrop layer-shell surface behind them. Backdrop must have non-zero opacity (`rgba(0,0,0,0.01)` minimum) for the compositor to deliver input events. Clicking the backdrop hides both the backdrop and the menu/panel.
+
+## Signal control
+
+| Signal | Value | Action |
+|--------|-------|--------|
+| SIGRTMIN+4 | ~38 | Toggle notification panel |
+| SIGRTMIN+5 | ~39 | Toggle DND |
+| SIGRTMIN+6 | ~40 | Show DND duration menu |
+| SIGRTMIN+11 | ~45 | (outbound) Waybar notification-module refresh |
+
+(Values approximate — glibc/musl differ; see `nwg_common::signals::sigrtmin()`.)
+
+## Waybar integration
+
+The daemon writes its current state to `$XDG_RUNTIME_DIR/mac-notifications-status.json` (unread count, DND status, etc.) and signals waybar via `SIGRTMIN+11` on state change — no polling. Waybar's `signal: 11` handler re-reads the file. See the README for the waybar module config snippet.
+
+## See also
+
+- `CHANGELOG.md` — user-visible changes per release, Keep-a-Changelog format.
+- `README.md` — public-facing docs + install matrix + waybar config + D-Bus service file setup.
+- [`nwg-common`](https://github.com/jasonherald/nwg-common) — shared library (Compositor trait for focus-on-click, icons, signals, layer-shell backdrops).
+- Parent monorepo archive: [jasonherald/mac-doc-hyprland](https://github.com/jasonherald/mac-doc-hyprland).
+- [Desktop Notifications Specification](https://specifications.freedesktop.org/notification-spec/latest/) — canonical reference for D-Bus protocol compliance.

--- a/docs/readme-drafts/CLAUDE-nwg-notifications.md
+++ b/docs/readme-drafts/CLAUDE-nwg-notifications.md
@@ -50,7 +50,7 @@ The daemon auto-starts the first time any app calls `org.freedesktop.Notificatio
 
 ## What lives where
 
-```
+```text
 src/
 ├── main.rs            # Coordinator (~160 lines)
 ├── config.rs          # clap CLI with PopupPosition enum

--- a/docs/readme-drafts/CLAUDE-nwg-notifications.md
+++ b/docs/readme-drafts/CLAUDE-nwg-notifications.md
@@ -32,7 +32,7 @@ make install PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin
 make install-dbus
 ```
 
-`make install-dbus` is ALWAYS user-scope (no sudo; drops the service file into `~/.local/share/dbus-1/services/`) regardless of `PREFIX`. D-Bus user services are per-user by convention, and installing the service file system-wide would break auto-activation for other users.
+`make install-dbus` is ALWAYS user-scope (no sudo; installs the service file into `~/.local/share/dbus-1/services/`) regardless of `PREFIX`. D-Bus user services are per-user by convention, and installing the service file system-wide would break auto-activation for other users.
 
 See the README for the full install matrix.
 

--- a/docs/readme-drafts/mac-doc-hyprland.md
+++ b/docs/readme-drafts/mac-doc-hyprland.md
@@ -12,7 +12,7 @@
 
 ## Migrating from `nwg-dock-hyprland`?
 
-The Rust port's dock is now called `nwg-dock` and supports both Hyprland and Sway in one binary. Existing `exec-once = nwg-dock-hyprland …` autostart lines keep working: `make install` in the [nwg-dock](https://github.com/jasonherald/nwg-dock) repo drops a `nwg-dock-hyprland` symlink pointing at the renamed binary, so no compositor config edits are needed.
+The Rust port's dock is now called `nwg-dock` and supports both Hyprland and Sway in one binary. Existing `exec-once = nwg-dock-hyprland …` autostart lines keep working: `make install` in the [nwg-dock](https://github.com/jasonherald/nwg-dock) repo installs a `nwg-dock-hyprland` symlink pointing at the renamed binary, so no compositor config edits are needed.
 
 ## History
 

--- a/docs/readme-drafts/mac-doc-hyprland.md
+++ b/docs/readme-drafts/mac-doc-hyprland.md
@@ -1,0 +1,25 @@
+# mac-doc-hyprland (archived)
+
+> [!NOTE]
+> **This repository has been archived.** The code was split into four per-tool repositories at v0.3.0. This repo preserves the pre-split git history and closed-issue record; all new issues, PRs, and releases happen in the new repos.
+
+| Tool | Repo | crates.io |
+|------|------|-----------|
+| `nwg-common` (shared library) | [jasonherald/nwg-common](https://github.com/jasonherald/nwg-common) | [`nwg-common`](https://crates.io/crates/nwg-common) |
+| `nwg-dock` (renamed from `nwg-dock-hyprland` — supports Hyprland + Sway) | [jasonherald/nwg-dock](https://github.com/jasonherald/nwg-dock) | [`nwg-dock`](https://crates.io/crates/nwg-dock) |
+| `nwg-drawer` | [jasonherald/nwg-drawer](https://github.com/jasonherald/nwg-drawer) | [`nwg-drawer`](https://crates.io/crates/nwg-drawer) |
+| `nwg-notifications` | [jasonherald/nwg-notifications](https://github.com/jasonherald/nwg-notifications) | [`nwg-notifications`](https://crates.io/crates/nwg-notifications) |
+
+## Migrating from `nwg-dock-hyprland`?
+
+The Rust port's dock is now called `nwg-dock` and supports both Hyprland and Sway in one binary. Existing `exec-once = nwg-dock-hyprland …` autostart lines keep working: `make install` in the [nwg-dock](https://github.com/jasonherald/nwg-dock) repo drops a `nwg-dock-hyprland` symlink pointing at the renamed binary, so no compositor config edits are needed.
+
+## History
+
+- Git log for everything up to v0.2.0 lives here.
+- v0.3.0 is where the split happened — each per-tool repo's CHANGELOG starts at v0.3.0 with a pointer back to this repo for earlier history.
+- See the original monorepo commit log for the porting work from [nwg-piotr](https://github.com/nwg-piotr)'s Go implementations.
+
+## License
+
+MIT. Each per-tool repo has its own `LICENSE` file with the same terms.

--- a/docs/readme-drafts/nwg-common.md
+++ b/docs/readme-drafts/nwg-common.md
@@ -1,0 +1,68 @@
+# nwg-common
+
+Shared library backing the [`nwg-dock`](https://github.com/jasonherald/nwg-dock),
+[`nwg-drawer`](https://github.com/jasonherald/nwg-drawer), and
+[`nwg-notifications`](https://github.com/jasonherald/nwg-notifications) ports —
+the macOS-style dock, app drawer, and notification daemon for
+[Hyprland](https://hyprland.org/) and [Sway](https://swaywm.org/), written in Rust.
+
+## What's in the box
+
+- **Compositor-neutral IPC abstraction.** A `Compositor` trait with Hyprland
+  and Sway backends, auto-detected from `HYPRLAND_INSTANCE_SIGNATURE` /
+  `SWAYSOCK` env vars. A null backend for graceful degradation on unsupported
+  compositors (Niri, river, Openbox, etc.). Consumers call `init_or_exit` or
+  `init_or_null` and only talk to the trait from then on.
+- **`.desktop` file handling.** Parser with locale-aware `Name` / `Comment`
+  resolution, FreeDesktop category assignment with secondary-category
+  mapping, icon file lookup, and user-configured preferred-app overrides.
+- **CSS loading + hot-reload.** GTK4 CssProvider loading with recursive
+  `@import` graph resolution, cycle detection, and an in-place file watcher
+  that survives both truncate-in-place and rename-swap save strategies.
+- **XDG paths.** Data / config / cache directory resolution following the
+  XDG Base Directory spec.
+- **Application launching.** Direct spawn and compositor-`exec` pathways,
+  plus a shared child-reaper thread so GUI-app processes don't zombify.
+  Handles `.desktop` field codes, theme prepends, and terminal launches.
+- **Shared pin file.** Atomic save / load with case-insensitive pin / unpin
+  for the `~/.cache/mac-dock-pinned` file used by the dock and drawer.
+- **RT-signal plumbing.** `SIGRTMIN+1..+6` helpers with runtime `SIGRTMIN`
+  query (correct on glibc and musl), plus SIGTERM and single-instance
+  signaling.
+- **Single-instance lock.** Per-user lock file with stale-PID recovery that
+  validates `/proc/<pid>/exe` against the caller's own binary to avoid
+  acting on recycled PIDs.
+- **Fullscreen layer-shell backdrops.** Per-monitor transparent surfaces
+  for click-outside-to-close UI patterns, across the drawer / notifications
+  panel / DND menu.
+
+## Stability contract
+
+`nwg-common` is in **0.x**. Per crates.io semver convention for `0.x`
+crates:
+
+- Breaking changes ship as **minor** bumps (`0.3 → 0.4`).
+- Additive changes ship as **patch** or **minor** depending on scope.
+- **1.0.0 is a deliberate decision** we'll make once the public API has
+  had real-world soak time across the three binaries that depend on it.
+  Don't expect it imminently — the point of the 0.x window is to let the
+  surface settle.
+
+Binaries consuming `nwg-common` should pin to `nwg-common = "0.3"` (or
+whatever the current minor is) so patch bumps flow automatically while
+minor bumps are opted into deliberately.
+
+The public surface is sealed behind `#![warn(missing_docs)]` — every item
+you can import is documented. See `cargo doc --open -p nwg-common`.
+
+## Pre-split history
+
+Before v0.3.0, this crate lived inside the
+[`mac-doc-hyprland`](https://github.com/jasonherald/mac-doc-hyprland)
+monorepo as `nwg-dock-common` at version 0.2.0. The full pre-split git
+history is preserved in the monorepo; this crate's `CHANGELOG.md`
+documents changes from v0.3.0 onward.
+
+## License
+
+MIT. See the `LICENSE` file in the repo root.

--- a/docs/readme-drafts/nwg-dock.md
+++ b/docs/readme-drafts/nwg-dock.md
@@ -2,7 +2,7 @@
 
 A macOS-style dock for [Hyprland](https://hyprland.org/) and [Sway](https://swaywm.org/), written in Rust.
 
-**Renamed from `nwg-dock-hyprland`.** The Rust port supports both Hyprland and Sway through one binary (Compositor trait + runtime `--wm` auto-detection), so the compositor-specific name didn't fit anymore. Existing users: `make install` drops a `nwg-dock-hyprland` → `nwg-dock` symlink so your `exec-once = nwg-dock-hyprland …` autostart line keeps working. See [Migrating from `nwg-dock-hyprland`](#migrating-from-nwg-dock-hyprland) below.
+**Renamed from `nwg-dock-hyprland`.** The Rust port supports both Hyprland and Sway through one binary (Compositor trait + runtime `--wm` auto-detection), so the compositor-specific name didn't fit anymore. Existing users: `make install` installs a `nwg-dock-hyprland` → `nwg-dock` symlink so your `exec-once = nwg-dock-hyprland …` autostart line keeps working. See [Migrating from `nwg-dock-hyprland`](#migrating-from-nwg-dock-hyprland) below.
 
 Ported from [nwg-piotr/nwg-dock-hyprland](https://github.com/nwg-piotr/nwg-dock-hyprland) (Hyprland-only Go) and informed by [nwg-piotr/nwg-dock](https://github.com/nwg-piotr/nwg-dock) (Sway-only Go), with enhancements the Go versions don't have.
 
@@ -80,7 +80,7 @@ sudo make install PREFIX=/usr
 cargo install nwg-dock
 ```
 
-`cargo install` only drops the `nwg-dock` binary in `~/.cargo/bin/`; the `nwg-dock-hyprland` symlink alias is a `make install` feature only. If you're migrating from `nwg-dock-hyprland` and using `cargo install`, update your autostart to `nwg-dock …`.
+`cargo install` only installs the `nwg-dock` binary in `~/.cargo/bin/`; the `nwg-dock-hyprland` symlink alias is a `make install` feature only. If you're migrating from `nwg-dock-hyprland` and using `cargo install`, update your autostart to `nwg-dock …`.
 
 ## Usage
 

--- a/docs/readme-drafts/nwg-dock.md
+++ b/docs/readme-drafts/nwg-dock.md
@@ -1,0 +1,183 @@
+# nwg-dock
+
+A macOS-style dock for [Hyprland](https://hyprland.org/) and [Sway](https://swaywm.org/), written in Rust.
+
+**Renamed from `nwg-dock-hyprland`.** The Rust port supports both Hyprland and Sway through one binary (Compositor trait + runtime `--wm` auto-detection), so the compositor-specific name didn't fit anymore. Existing users: `make install` drops a `nwg-dock-hyprland` → `nwg-dock` symlink so your `exec-once = nwg-dock-hyprland …` autostart line keeps working. See [Migrating from `nwg-dock-hyprland`](#migrating-from-nwg-dock-hyprland) below.
+
+Ported from [nwg-piotr/nwg-dock-hyprland](https://github.com/nwg-piotr/nwg-dock-hyprland) (Hyprland-only Go) and informed by [nwg-piotr/nwg-dock](https://github.com/nwg-piotr/nwg-dock) (Sway-only Go), with enhancements the Go versions don't have.
+
+## Features
+
+- **Multi-monitor** — dock appears on all monitors simultaneously
+- **Multi-compositor** — Hyprland and Sway via auto-detection (override with `--wm`)
+- **Content-width** — floats centered at screen edge, sized to its icons
+- **Auto-hide** — compositor IPC cursor tracking with configurable timeout
+- **Drag-to-reorder** — drag any pinned icon (running or not) to rearrange
+- **Drag-to-remove** — drag an icon off the dock to unpin it (like macOS)
+- **Dock settings menu** — right-click dock background to lock/unlock arrangement
+- **Configurable opacity** — `--opacity 0-100` for translucent or opaque dock
+- **Right-click menus** — pin/unpin, close, toggle floating, fullscreen, move to workspace
+- **Launch animation** — optional bounce animation on dock icons while an app is starting (`--launch-animation`)
+- **Middle-click** — launch new instance of any running app
+- **Monitor hotplug** — dock windows reconcile automatically when monitors are added/removed
+- **Rotated/scaled monitors** — cursor tracking works correctly with portrait and scaled displays
+- **Icon scaling** — icons shrink automatically when many apps are open
+- **Instant pin sync** — inotify-based, shared with [`nwg-drawer`](https://github.com/jasonherald/nwg-drawer)
+- **Kill-proof** — ignores compositor close requests (Hyprland `killactive` / Super+Q) so the dock can't be accidentally closed; use `make stop` or `pkill -f nwg-dock` to stop it intentionally
+- **Go flag compatibility** — accepts original Go nwg-dock-hyprland flag names
+
+## Install
+
+### Requirements
+
+- **Rust 1.95** or later (pinned in `rust-toolchain.toml`; rustup picks it up automatically)
+- **GTK4** and **gtk4-layer-shell** system libraries
+- A supported compositor: **Hyprland** or **Sway**
+
+### Install system dependencies
+
+```bash
+# Arch Linux
+sudo pacman -S gtk4 gtk4-layer-shell
+
+# Ubuntu/Debian
+sudo apt install libgtk-4-dev libgtk4-layer-shell-dev
+
+# Fedora
+sudo dnf install gtk4-devel gtk4-layer-shell-devel
+```
+
+### `make install` — three invocations
+
+The Makefile supports three ways to install depending on where you want the binary to land.
+
+**Default — system-wide (needs sudo):**
+
+```bash
+sudo make install
+```
+
+Writes:
+- `nwg-dock` → `/usr/local/bin/nwg-dock`
+- Legacy symlink → `/usr/local/bin/nwg-dock-hyprland` (so old autostart lines keep working)
+- Data files → `/usr/local/share/nwg-dock/`
+
+**No-sudo, dev workflow (useful when working from a clone):**
+
+```bash
+make install PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin
+```
+
+**Distro-parity (matches Go upstream's `/usr/bin` exactly):**
+
+```bash
+sudo make install PREFIX=/usr
+```
+
+### From crates.io
+
+```bash
+cargo install nwg-dock
+```
+
+`cargo install` only drops the `nwg-dock` binary in `~/.cargo/bin/`; the `nwg-dock-hyprland` symlink alias is a `make install` feature only. If you're migrating from `nwg-dock-hyprland` and using `cargo install`, update your autostart to `nwg-dock …`.
+
+## Usage
+
+```bash
+# Basic — auto-hide, 48px icons, translucent
+nwg-dock -d -i 48 --mb 10 --hide-timeout 400 --opacity 75
+
+# With launch animation and drawer integration
+nwg-dock -d -i 48 --mb 10 --hide-timeout 400 --opacity 75 --launch-animation -c "nwg-drawer --pb-auto"
+
+# Force Sway backend (auto-detection is usually enough)
+nwg-dock --wm sway
+```
+
+## Compositor setup
+
+```bash
+# Print Hyprland autostart snippets
+make setup-hyprland
+
+# Print Sway autostart snippets
+make setup-sway
+```
+
+### Hyprland autostart example
+
+```ini
+# ~/.config/hypr/autostart.conf
+exec-once = uwsm-app -- nwg-dock -d -i 48 --mb 10 --hide-timeout 400 --opacity 75 --launch-animation -c "nwg-drawer --opacity 88 --pb-auto"
+```
+
+## Signal control
+
+```bash
+# Toggle visibility
+pkill -f -35 nwg-dock     # SIGRTMIN+1
+
+# Show
+pkill -f -36 nwg-dock     # SIGRTMIN+2
+
+# Hide
+pkill -f -37 nwg-dock     # SIGRTMIN+3
+```
+
+## Theming
+
+The dock loads CSS from `~/.config/nwg-dock-hyprland/style.css` (path kept for continuity with the Go predecessor). Changes are picked up instantly via live file-change detection — no restart or signal needed. Hot-reload follows the full `@import` graph, so theme managers like [tinty](https://github.com/tinted-theming/tinty) or stylix work out of the box.
+
+Override the path with `-s /path/to/custom.css`.
+
+Three CSS layers are stacked, highest priority last:
+
+1. **Embedded defaults** — compact button sizing, indicator spacing, etc.
+2. **Programmatic overrides** — `--opacity` and bounce animation keyframes
+3. **Your CSS file** — always wins
+
+### base16 themes via tinty
+
+[tinty](https://github.com/tinted-theming/tinty) + [tinted-nwg-dock](https://github.com/tinted-theming/tinted-nwg-dock) templates retheme the dock live. See the tinted-nwg-dock README for setup; apply a theme with:
+
+```bash
+tinty apply base16-tokyo-night-dark
+```
+
+## Migrating from `nwg-dock-hyprland`
+
+If you're coming from either the Go `nwg-dock-hyprland` or an older Rust build where the binary was called `nwg-dock-hyprland`:
+
+- **Installed via `make install`** — nothing to do. The `nwg-dock-hyprland` symlink is installed alongside the new `nwg-dock` binary, so `exec-once = nwg-dock-hyprland …` keeps working.
+- **Installed via `cargo install`** — update your autostart to `nwg-dock …` (or invoke `nwg-dock` directly). `cargo install` doesn't create the symlink.
+
+The preferred canonical command going forward is `nwg-dock`. The `nwg-dock-hyprland` symlink is deprecated and will be removed in a future minor release; CHANGELOGs will give advance notice.
+
+## Shared pin file
+
+Pin state lives at `~/.cache/mac-dock-pinned`, shared with [`nwg-drawer`](https://github.com/jasonherald/nwg-drawer). Pin an app from either side (dock: right-click → Pin; drawer: right-click). Drag icons in the dock to reorder; drag off to unpin.
+
+## Contributing
+
+PRs welcome. `main` is protected — open from a feature branch. Run `make lint` (fmt + clippy + test + deny + audit) locally before requesting review. CI runs the equivalent checks across separate workflows plus CodeRabbit.
+
+User-visible PRs add a CHANGELOG bullet under `## [x.y.z] — Unreleased` in `CHANGELOG.md`, following [Keep a Changelog](https://keepachangelog.com).
+
+## Deviations from Go `nwg-dock-hyprland`
+
+- **Multi-compositor** — Go version is Hyprland-only; Rust port supports both via `nwg-common`'s Compositor trait.
+- **Shared pin file** — Go dock uses `~/.cache/nwg-dock-pinned`; Rust port shares `~/.cache/mac-dock-pinned` with the drawer for instant two-way sync.
+- **Per-monitor windows** — Go creates one window; Rust creates one per monitor for better multi-monitor support.
+- **Smart rebuild** — Go force-rebuilds on every active-window event; Rust rebuilds only when the client list or active window actually changes.
+- **Drag-to-reorder** — new feature not in the Go dock.
+- **CLI flag naming** — multi-word flags standardized to kebab-case. Multi-char Go short forms (`-hd`, `-iw`, `-is`) not available; use the long forms.
+- **Fuzzy class matching** — desktop file `github-desktop` vs compositor class `github desktop` are matched automatically.
+
+## Credits
+
+Ported from [nwg-piotr/nwg-dock-hyprland](https://github.com/nwg-piotr/nwg-dock-hyprland) (MIT), informed by [nwg-piotr/nwg-dock](https://github.com/nwg-piotr/nwg-dock) (MIT).
+
+## License
+
+MIT. See `LICENSE`.

--- a/docs/readme-drafts/nwg-drawer.md
+++ b/docs/readme-drafts/nwg-drawer.md
@@ -1,0 +1,161 @@
+# nwg-drawer
+
+A Launchpad-style application launcher and file search overlay for [Hyprland](https://hyprland.org/), [Sway](https://swaywm.org/), and any Wayland compositor with layer-shell support. Written in Rust.
+
+Ported from [nwg-piotr/nwg-drawer](https://github.com/nwg-piotr/nwg-drawer) (Go) with enhancements: compositor-neutral IPC via the Compositor trait, shared pin state with [`nwg-dock`](https://github.com/jasonherald/nwg-dock), and graceful fallback on unsupported compositors (Niri, river, Openbox).
+
+## Features
+
+- **Full-screen overlay** — dark transparent Launchpad-style launcher
+- **Keyboard navigation** — arrow keys between icons, Enter to launch, type to search
+- **Category filtering** — filter bar with per-category buttons
+- **Description line** — status bar shows app description on hover/focus
+- **Power bar** — lock/exit/reboot/sleep/poweroff with `--pb-auto` auto-detection
+- **Configurable opacity** — `--opacity 0-100` for background transparency
+- **Subsequence search** — type to filter apps by name, description, or command
+- **File search** — columnar results with system theme icons, sorted alphabetically
+- **Math evaluation** — type expressions like `2+2` and get results with clipboard copy (via `exmex`)
+- **Command execution** — prefix with `:` to run arbitrary commands
+- **Pin sync** — shared pin file with [`nwg-dock`](https://github.com/jasonherald/nwg-dock); changes reflect instantly on both via inotify
+- **Compositor-neutral** — runs on Hyprland, Sway, and any layer-shell-capable compositor. Graceful feature degradation on the null backend (Niri, river, Openbox, etc.)
+- **Go flag compatibility** — accepts original Go nwg-drawer flag names (`--pbexit`, `--nocats`, etc.)
+
+## Install
+
+### Requirements
+
+- **Rust 1.95** or later (pinned in `rust-toolchain.toml`; rustup picks it up automatically)
+- **GTK4** and **gtk4-layer-shell** system libraries
+- A Wayland compositor with `wlr-layer-shell` support (Hyprland, Sway, Niri, river, etc.)
+
+### Install system dependencies
+
+```bash
+# Arch Linux
+sudo pacman -S gtk4 gtk4-layer-shell
+
+# Ubuntu/Debian
+sudo apt install libgtk-4-dev libgtk4-layer-shell-dev
+
+# Fedora
+sudo dnf install gtk4-devel gtk4-layer-shell-devel
+```
+
+### `make install` — three invocations
+
+**Default — system-wide (needs sudo):**
+
+```bash
+sudo make install
+```
+
+Writes:
+- `nwg-drawer` → `/usr/local/bin/nwg-drawer`
+- Data files (drawer.css, `img/`) → `/usr/local/share/nwg-drawer/`
+
+**No-sudo, dev workflow (useful when working from a clone):**
+
+```bash
+make install PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin
+```
+
+**Distro-parity (matches Go upstream's `/usr/bin` exactly):**
+
+```bash
+sudo make install PREFIX=/usr
+```
+
+### From crates.io
+
+```bash
+cargo install nwg-drawer
+```
+
+Installs only the binary; the drawer-installed data assets (`drawer.css`, category icons) are not copied. The drawer falls back to its embedded defaults when the filesystem assets are missing, so `cargo install` alone gets you a working drawer; `make install` adds user-customizable CSS and icons at the system location.
+
+## Usage
+
+```bash
+# Basic with auto-detected power bar
+nwg-drawer --pb-auto
+
+# Fully configured
+nwg-drawer --opacity 88 --pb-auto --columns 8
+
+# Resident mode (stays in memory, toggle with signals)
+nwg-drawer -r --pb-auto
+
+# Force Sway backend (usually auto-detected)
+nwg-drawer --wm sway
+```
+
+## Integration with the dock
+
+The drawer is typically launched by the dock's launcher button. Configure the dock with `-c "nwg-drawer --pb-auto"` to wire it up:
+
+```ini
+# ~/.config/hypr/autostart.conf (Hyprland example)
+exec-once = nwg-dock -d -i 48 --mb 10 --hide-timeout 400 --launch-animation -c "nwg-drawer --opacity 88 --pb-auto"
+```
+
+Pins work bidirectionally — pin an app from the drawer (right-click → Pin) and it shows up in the dock instantly, and vice versa.
+
+## Signal control (resident mode only)
+
+```bash
+# Toggle visibility
+pkill -f -35 nwg-drawer     # SIGRTMIN+1
+
+# Show
+pkill -f -36 nwg-drawer     # SIGRTMIN+2
+
+# Hide
+pkill -f -37 nwg-drawer     # SIGRTMIN+3
+```
+
+## Theming
+
+The drawer loads CSS from `~/.config/nwg-drawer/drawer.css`. Changes are picked up instantly via live file-change detection — no restart or signal needed. Hot-reload follows the full `@import` graph, so [tinty](https://github.com/tinted-theming/tinty) and similar theme managers work out of the box.
+
+Override the path with `-s /path/to/custom.css`.
+
+### base16 themes via tinty
+
+Use the [tinted-nwg-dock](https://github.com/tinted-theming/tinted-nwg-dock) templates with the drawer hook:
+
+```toml
+[[items]]
+name = "base16-nwg-drawer"
+path = "https://github.com/tinted-theming/tinted-nwg-dock"
+themes-dir = "themes"
+hook = "cp '%f' ~/.config/nwg-drawer/drawer.css"
+supported-systems = ["base16"]
+```
+
+Applying a theme reloads the drawer live.
+
+## Shared pin file
+
+Pin state lives at `~/.cache/mac-dock-pinned`, shared with [`nwg-dock`](https://github.com/jasonherald/nwg-dock). Pin/unpin from either side; the other picks up the change via inotify within milliseconds.
+
+## Contributing
+
+PRs welcome. `main` is protected — open from a feature branch. Run `make lint` (fmt + clippy + test + deny + audit) locally before requesting review.
+
+User-visible PRs add a CHANGELOG bullet under `## [x.y.z] — Unreleased` in `CHANGELOG.md`, following [Keep a Changelog](https://keepachangelog.com).
+
+## Deviations from Go `nwg-drawer`
+
+- **Multi-compositor** — Go version is Sway/Hyprland via separate branches; Rust port auto-detects and degrades gracefully on unsupported compositors.
+- **Shared pin file** — Go drawer uses `~/.cache/nwg-pin-cache`; Rust port shares `~/.cache/mac-dock-pinned` with the dock.
+- **Math evaluation** — Go uses the `expr` library for arbitrary expression evaluation; Rust port uses the [`exmex`](https://crates.io/crates/exmex) crate (safe parser, no `eval`/shell) with a small custom operator factory that adds `pi` / `π`, `%` modulo, and base-10 `log`. Scoped to pure arithmetic (no variables) so random search queries don't accidentally evaluate.
+- **CLI flag naming** — multi-word flags standardized to kebab-case (`--nocats` → `--no-cats`, `--pbsize` → `--pb-size`). Multi-char Go short forms not available; use long forms.
+- **Launcher auto-detection** — unrelated but worth noting: if the configured launcher command is missing, the launcher button in the dock hides automatically; the drawer itself has no such dependency.
+
+## Credits
+
+Ported from [nwg-piotr/nwg-drawer](https://github.com/nwg-piotr/nwg-drawer) (MIT).
+
+## License
+
+MIT. See `LICENSE`.

--- a/docs/readme-drafts/nwg-notifications.md
+++ b/docs/readme-drafts/nwg-notifications.md
@@ -76,7 +76,7 @@ make install-dbus
 cargo install nwg-notifications
 ```
 
-`cargo install` only drops the binary. You'll need to write the D-Bus service file yourself (see [D-Bus service](#d-bus-service) below) — it's a ~5-line file pointing at `~/.cargo/bin/nwg-notifications`.
+`cargo install` only installs the binary. You'll need to write the D-Bus service file yourself (see [D-Bus service](#d-bus-service) below) — it's a ~5-line file pointing at `~/.cargo/bin/nwg-notifications`.
 
 ## Usage
 
@@ -90,7 +90,7 @@ nwg-notifications --wm sway --persist
 
 ## D-Bus service
 
-`make install-dbus` drops this file into `~/.local/share/dbus-1/services/`. If you're cargo-installing, create it manually:
+`make install-dbus` installs this file into `~/.local/share/dbus-1/services/`. If you're cargo-installing, create it manually:
 
 ```ini
 # ~/.local/share/dbus-1/services/org.freedesktop.Notifications.service

--- a/docs/readme-drafts/nwg-notifications.md
+++ b/docs/readme-drafts/nwg-notifications.md
@@ -1,0 +1,166 @@
+# nwg-notifications
+
+A D-Bus notification daemon and notification center for [Hyprland](https://hyprland.org/) and [Sway](https://swaywm.org/), written in Rust.
+
+Claims `org.freedesktop.Notifications`, shows popup toasts, and ships a slide-out history panel with Do-Not-Disturb controls and optional waybar integration. Built alongside [`nwg-dock`](https://github.com/jasonherald/nwg-dock) and [`nwg-drawer`](https://github.com/jasonherald/nwg-drawer) to replace [mako](https://github.com/emersion/mako) in the mac-doc-hyprland stack, but runs standalone.
+
+## Features
+
+- **D-Bus notification daemon** — replaces mako; claims `org.freedesktop.Notifications`
+- **Popup toasts** — top-right corner, auto-dismiss, click-to-focus sending app
+- **Deep-linking** — clicking a notification tells the app to open the specific item
+- **Auto-dismiss** — popups dismissed when app calls CloseNotification (e.g., Slack read)
+- **Action buttons** — shows Reply/Open/etc. buttons, emits `ActionInvoked` D-Bus signal
+- **History panel** — slide-out from right, grouped by app with collapse/expand
+- **Click-outside-to-close** — backdrop overlay + Escape key
+- **Dismiss controls** — per-notification, per-app group, or clear all
+- **Do Not Disturb** — toggle via panel button, signal, or waybar right-click menu
+- **Timed DND** — 1 hour, 2 hours, until tomorrow with expiry countdown
+- **Waybar integration** — bell icon with unread count, left-click toggles panel, right-click opens DND menu
+- **Persistence** — notification history saved across restarts with `--persist`
+- **Focused monitor** — popups appear on the currently focused monitor
+
+## Install
+
+### Requirements
+
+- **Rust 1.95** or later (pinned in `rust-toolchain.toml`; rustup picks it up automatically)
+- **GTK4** and **gtk4-layer-shell** system libraries
+- A Wayland compositor with `wlr-layer-shell` support (Hyprland, Sway)
+
+### Install system dependencies
+
+```bash
+# Arch Linux
+sudo pacman -S gtk4 gtk4-layer-shell
+
+# Ubuntu/Debian
+sudo apt install libgtk-4-dev libgtk4-layer-shell-dev
+
+# Fedora
+sudo dnf install gtk4-devel gtk4-layer-shell-devel
+```
+
+### `make install` — three invocations for the binary + a user-scope `install-dbus`
+
+The binary install has three invocations. The **D-Bus service file always lands in user-scope** (`~/.local/share/dbus-1/services/`) regardless of `PREFIX` — D-Bus user services are per-user by convention, and installing the service file system-wide would break auto-activation for other users on the same machine.
+
+**Default — system-wide binary + user-scope service:**
+
+```bash
+sudo make install
+make install-dbus
+```
+
+Writes:
+- `nwg-notifications` → `/usr/local/bin/nwg-notifications`
+- D-Bus service file → `~/.local/share/dbus-1/services/org.freedesktop.Notifications.service` (no sudo)
+
+**No-sudo, dev workflow:**
+
+```bash
+make install PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin
+make install-dbus
+```
+
+**Distro-parity:**
+
+```bash
+sudo make install PREFIX=/usr
+make install-dbus
+```
+
+### From crates.io
+
+```bash
+cargo install nwg-notifications
+```
+
+`cargo install` only drops the binary. You'll need to write the D-Bus service file yourself (see [D-Bus service](#d-bus-service) below) — it's a ~5-line file pointing at `~/.cargo/bin/nwg-notifications`.
+
+## Usage
+
+```bash
+# With history persistence
+nwg-notifications --persist
+
+# Force Sway backend (usually auto-detected)
+nwg-notifications --wm sway --persist
+```
+
+## D-Bus service
+
+`make install-dbus` drops this file into `~/.local/share/dbus-1/services/`. If you're cargo-installing, create it manually:
+
+```ini
+# ~/.local/share/dbus-1/services/org.freedesktop.Notifications.service
+[D-BUS Service]
+Name=org.freedesktop.Notifications
+Exec=/home/YOU/.cargo/bin/nwg-notifications --persist
+```
+
+Once registered, the daemon auto-starts the first time any app calls `org.freedesktop.Notifications`.
+
+## Hyprland autostart
+
+```ini
+# ~/.config/hypr/autostart.conf
+exec-once = uwsm-app -- nwg-notifications --persist
+```
+
+Autostart isn't strictly required thanks to D-Bus auto-activation, but it makes the daemon ready before the first notification arrives (avoids a few-hundred-millisecond delay on your first toast).
+
+## Signal control
+
+```bash
+# Toggle notification panel
+pkill -f -38 nwg-notifications     # SIGRTMIN+4
+
+# Toggle DND
+pkill -f -39 nwg-notifications     # SIGRTMIN+5
+
+# Open DND duration menu
+pkill -f -40 nwg-notifications     # SIGRTMIN+6
+```
+
+## Waybar integration
+
+Add to `~/.config/waybar/config.jsonc`:
+
+```jsonc
+"custom/notifications": {
+    "exec": "cat $XDG_RUNTIME_DIR/mac-notifications-status.json 2>/dev/null || echo '{\"text\":\"\",\"alt\":\"empty\",\"class\":\"empty\"}'",
+    "return-type": "json",
+    "format": "{}",
+    "on-click": "pkill -f -38 nwg-notifications",
+    "on-click-right": "pkill -f -40 nwg-notifications",
+    "signal": 11,
+    "interval": "once"
+}
+```
+
+The daemon writes its current state to `$XDG_RUNTIME_DIR/mac-notifications-status.json` and signals waybar (`SIGRTMIN+11`, which waybar receives as `signal: 11`) whenever the state changes — no polling.
+
+## Theming
+
+Styling is embedded via `include_str!`; there's no user-writable `notifications.css` today. If you need to customize appearance, fork the crate and edit `assets/notifications.css`, or open an issue to discuss exposing it.
+
+## Contributing
+
+PRs welcome. `main` is protected — open from a feature branch. Run `make lint` (fmt + clippy + test + deny + audit) locally before requesting review.
+
+User-visible PRs add a CHANGELOG bullet under `## [x.y.z] — Unreleased` in `CHANGELOG.md`, following [Keep a Changelog](https://keepachangelog.com).
+
+## Background: why not mako?
+
+Mako is great, but:
+
+1. The mac-doc-hyprland stack wanted a single look/feel across the dock, drawer, and notification center — GTK4 layer-shell surfaces make theming coherent across all three.
+2. We wanted history + grouping + click-to-focus as first-class features, not add-ons.
+3. Writing a D-Bus notification server in Rust on `gio::bus_own_name` turned out to be less code than expected — no async bridge, no external crate, directly on the glib main loop.
+
+Run `nwg-notifications` instead of mako, or alongside (they'll race for the name — whichever claimed it first wins).
+
+## License
+
+MIT. See `LICENSE`.


### PR DESCRIPTION
## Summary
Inventories the current monorepo README + CLAUDE.md by section and drops a ready-to-copy draft per target repo under `docs/readme-drafts/`. Phase 1–4 extraction PRs copy these verbatim as starting READMEs / CLAUDE.mds rather than authoring on the fly.

No production code touched — 9 new markdown files, 1,078 lines.

## Files

| Target repo | README draft | CLAUDE.md draft |
|-------------|--------------|-----------------|
| `jasonherald/mac-doc-hyprland` (archived) | `mac-doc-hyprland.md` | — (monorepo CLAUDE.md stays, becomes stale on archive) |
| `jasonherald/nwg-common` | `nwg-common.md` (reuses the library README seeded in #85) | `CLAUDE-nwg-common.md` |
| `jasonherald/nwg-dock` | `nwg-dock.md` | `CLAUDE-nwg-dock.md` |
| `jasonherald/nwg-drawer` | `nwg-drawer.md` | `CLAUDE-nwg-drawer.md` |
| `jasonherald/nwg-notifications` | `nwg-notifications.md` | `CLAUDE-nwg-notifications.md` |

## Content coverage

Walked every section of the current `README.md` and confirmed each lands somewhere:

- **Features/Dock/Drawer/Notifications/Shared** → split across the four per-tool READMEs.
- **Installation (requirements + quick install + system deps + make targets + manual install + cargo install)** → each binary README carries the three install invocations from epic §3.6 (sudo default / no-sudo dev / distro-parity), plus a `cargo install` note.
- **Compositor setup + autostart snippets** → dock + notifications.
- **Usage** → per-tool.
- **D-Bus service file** → notifications only.
- **Signal control** → split per-binary with the relevant signal numbers.
- **Waybar module** → notifications only.
- **Architecture** → each CLAUDE.md gets a "what lives where" map for its repo.
- **Shared pin file** → dock + drawer READMEs mention; nwg-common CLAUDE.md owns the contract doc.
- **Theming** (CSS paths, priority layers, smooth transitions, base16 via tinty) → dock + drawer.
- **Deviations from Go** → split per-binary.
- **Code Quality** → pared back across repos (each gets its own scope).
- **Contributing** → each repo.

## Install-invocation compliance (per epic §3.6)

- Each binary README documents: default `sudo make install`, no-sudo `PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin`, and distro-parity `PREFIX=/usr`.
- Each binary CLAUDE.md leads its "Install (dev workflow)" section with the no-sudo invocation so contributors working from a clone don't accidentally sudo-install to `/usr/local`.
- Notifications README explicitly notes `install-dbus` is always user-scope regardless of `PREFIX`.
- `nwg-common` README has no install section — library is consumed via `cargo add nwg-common`.

## Test plan
- [x] Every section of the current monorepo README mapped to at least one draft
- [x] Every binary README covers all three install invocations
- [x] Every binary CLAUDE.md documents the no-sudo dev override
- [x] `cargo fmt --all -- --check` clean (no code changes)
- [ ] CI + CodeRabbit review

Closes #113.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive draft docs for the shared library, dock, drawer, notifications, and an archived project note. Covers purpose and capabilities, installation and no-sudo dev install workflows, usage examples and runtime controls, build/test/lint guidance, theming and live CSS reload, shared pin-file sync and IPC/D-Bus contracts, developer conventions, migration guidance, and licensing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->