### PR TITLE
Mark Wm* types #[non_exhaustive] + add fluent setters (#117)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -42,7 +42,7 @@ reviews:
         - No command injection in hyprctl/swaymsg dispatch strings
         - Thread safety: Rc<dyn Compositor> must never cross thread boundaries
         - WmEventStream must be Send (used in background threads)
-        - Wm* types (WmClient, WmMonitor, WmWorkspace, WmEvent) are public API; once #117 lands they will be #[non_exhaustive] with builder construction — never construct via struct literal from outside nwg-common.
+        - Wm* types (WmClient, WmMonitor, WmWorkspace, WmEvent) are public API and #[non_exhaustive]. External crates must construct via `Default::default()` + the `with_*` fluent setters — never via struct literal. Same-crate (nwg-common) construction sites keep using struct literals; that's unaffected by the attribute.
     - path: "crates/nwg-common/src/launch.rs"
       instructions: |
         App launching pipeline. Verify:

--- a/crates/nwg-common/CHANGELOG.md
+++ b/crates/nwg-common/CHANGELOG.md
@@ -78,6 +78,12 @@ the monorepo.
   at the crate root, so `cargo doc --no-deps -p nwg-common` runs
   warning-free and `cargo rustdoc -p nwg-common -- -D missing-docs`
   succeeds.
+- `compositor::{WmClient, WmMonitor, WmWorkspace, WmEvent}` are now
+  `#[non_exhaustive]`. External crates must construct via
+  `Default::default()` + the new fluent `with_*` setters
+  (`WmMonitor::default().with_id(1).with_name("DP-1") …`) rather than
+  struct literals; future field additions won't break downstream
+  construction or exhaustive matches. Same-crate usage is unaffected.
 
 ### Fixed
 

--- a/crates/nwg-common/src/compositor/types.rs
+++ b/crates/nwg-common/src/compositor/types.rs
@@ -1,5 +1,11 @@
 /// Compositor-neutral window representation.
+///
+/// Marked `#[non_exhaustive]` so additive field changes don't break
+/// downstream match / struct-literal sites. External consumers construct
+/// via [`WmClient::default`] plus the `with_*` setters below; same-crate
+/// usage is unaffected by the attribute.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct WmClient {
     /// Compositor-specific identifier (Hyprland: `0x1234`, Sway: `42`).
     pub id: String,
@@ -24,8 +30,62 @@ pub struct WmClient {
     pub fullscreen: bool,
 }
 
+impl WmClient {
+    /// Fluent setter for [`Self::id`].
+    pub fn with_id(mut self, id: impl Into<String>) -> Self {
+        self.id = id.into();
+        self
+    }
+    /// Fluent setter for [`Self::class`].
+    pub fn with_class(mut self, class: impl Into<String>) -> Self {
+        self.class = class.into();
+        self
+    }
+    /// Fluent setter for [`Self::initial_class`].
+    pub fn with_initial_class(mut self, initial_class: impl Into<String>) -> Self {
+        self.initial_class = initial_class.into();
+        self
+    }
+    /// Fluent setter for [`Self::title`].
+    pub fn with_title(mut self, title: impl Into<String>) -> Self {
+        self.title = title.into();
+        self
+    }
+    /// Fluent setter for [`Self::pid`].
+    pub fn with_pid(mut self, pid: i32) -> Self {
+        self.pid = pid;
+        self
+    }
+    /// Fluent setter for [`Self::workspace`].
+    pub fn with_workspace(mut self, workspace: WmWorkspace) -> Self {
+        self.workspace = workspace;
+        self
+    }
+    /// Fluent setter for [`Self::floating`].
+    pub fn with_floating(mut self, floating: bool) -> Self {
+        self.floating = floating;
+        self
+    }
+    /// Fluent setter for [`Self::monitor_id`].
+    pub fn with_monitor_id(mut self, monitor_id: i32) -> Self {
+        self.monitor_id = monitor_id;
+        self
+    }
+    /// Fluent setter for [`Self::fullscreen`].
+    pub fn with_fullscreen(mut self, fullscreen: bool) -> Self {
+        self.fullscreen = fullscreen;
+        self
+    }
+}
+
 /// Compositor-neutral monitor/output.
+///
+/// Marked `#[non_exhaustive]` so additive field changes don't break
+/// downstream match / struct-literal sites. External consumers construct
+/// via [`WmMonitor::default`] plus the `with_*` setters below; same-crate
+/// usage is unaffected by the attribute.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct WmMonitor {
     /// Compositor-assigned numeric ID. Matches [`WmClient::monitor_id`].
     pub id: i32,
@@ -47,8 +107,62 @@ pub struct WmMonitor {
     pub active_workspace: WmWorkspace,
 }
 
+impl WmMonitor {
+    /// Fluent setter for [`Self::id`].
+    pub fn with_id(mut self, id: i32) -> Self {
+        self.id = id;
+        self
+    }
+    /// Fluent setter for [`Self::name`].
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+    /// Fluent setter for [`Self::width`].
+    pub fn with_width(mut self, width: i32) -> Self {
+        self.width = width;
+        self
+    }
+    /// Fluent setter for [`Self::height`].
+    pub fn with_height(mut self, height: i32) -> Self {
+        self.height = height;
+        self
+    }
+    /// Fluent setter for [`Self::x`].
+    pub fn with_x(mut self, x: i32) -> Self {
+        self.x = x;
+        self
+    }
+    /// Fluent setter for [`Self::y`].
+    pub fn with_y(mut self, y: i32) -> Self {
+        self.y = y;
+        self
+    }
+    /// Fluent setter for [`Self::scale`].
+    pub fn with_scale(mut self, scale: f64) -> Self {
+        self.scale = scale;
+        self
+    }
+    /// Fluent setter for [`Self::focused`].
+    pub fn with_focused(mut self, focused: bool) -> Self {
+        self.focused = focused;
+        self
+    }
+    /// Fluent setter for [`Self::active_workspace`].
+    pub fn with_active_workspace(mut self, active_workspace: WmWorkspace) -> Self {
+        self.active_workspace = active_workspace;
+        self
+    }
+}
+
 /// Compositor-neutral workspace reference.
+///
+/// Marked `#[non_exhaustive]` so additive field changes don't break
+/// downstream match / struct-literal sites. External consumers construct
+/// via [`WmWorkspace::default`] plus the `with_*` setters below; same-crate
+/// usage is unaffected by the attribute.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct WmWorkspace {
     /// Compositor-assigned numeric workspace ID.
     pub id: i32,
@@ -56,8 +170,27 @@ pub struct WmWorkspace {
     pub name: String,
 }
 
+impl WmWorkspace {
+    /// Fluent setter for [`Self::id`].
+    pub fn with_id(mut self, id: i32) -> Self {
+        self.id = id;
+        self
+    }
+    /// Fluent setter for [`Self::name`].
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+}
+
 /// Events from the compositor event stream.
+///
+/// Marked `#[non_exhaustive]` so additional variants (e.g. the pending
+/// [`WorkspaceChanged`](#) variant tracked in #127) can be added without
+/// breaking downstream pattern-match sites. Consumers should include a
+/// `_ => ...` fallback arm.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum WmEvent {
     /// Active window changed. Contains the window id.
     ActiveWindowChanged(String),

--- a/crates/nwg-dock/src/ui/hotspot/cursor_poller.rs
+++ b/crates/nwg-dock/src/ui/hotspot/cursor_poller.rs
@@ -403,7 +403,7 @@ mod tests {
             .with_y(y)
             .with_width(w)
             .with_height(h)
-            .with_scale(1.0)
+            .with_scale(1.0) // test fixture — no HiDPI scaling
             .with_active_workspace(
                 WmWorkspace::default()
                     .with_id(active_workspace_id)
@@ -423,7 +423,7 @@ mod tests {
             .with_class("test")
             .with_initial_class("test")
             .with_title("test")
-            .with_pid(1)
+            .with_pid(1) // arbitrary non-zero PID for this fixture
             .with_workspace(
                 WmWorkspace::default()
                     .with_id(workspace_id)

--- a/crates/nwg-dock/src/ui/hotspot/cursor_poller.rs
+++ b/crates/nwg-dock/src/ui/hotspot/cursor_poller.rs
@@ -395,20 +395,20 @@ mod tests {
         h: i32,
         active_workspace_id: i32,
     ) -> WmMonitor {
-        WmMonitor {
-            id,
-            name: name.to_string(),
-            x,
-            y,
-            width: w,
-            height: h,
-            scale: 1.0,
-            focused: false,
-            active_workspace: WmWorkspace {
-                id: active_workspace_id,
-                name: format!("{}", active_workspace_id),
-            },
-        }
+        // `WmMonitor` is #[non_exhaustive] — construct via Default + fluent setters.
+        WmMonitor::default()
+            .with_id(id)
+            .with_name(name)
+            .with_x(x)
+            .with_y(y)
+            .with_width(w)
+            .with_height(h)
+            .with_scale(1.0)
+            .with_active_workspace(
+                WmWorkspace::default()
+                    .with_id(active_workspace_id)
+                    .with_name(format!("{}", active_workspace_id)),
+            )
     }
 
     fn test_client(monitor_id: i32, fullscreen: bool) -> WmClient {
@@ -417,20 +417,20 @@ mod tests {
     }
 
     fn test_client_on_workspace(monitor_id: i32, fullscreen: bool, workspace_id: i32) -> WmClient {
-        WmClient {
-            id: format!("0x{}", monitor_id),
-            class: "test".into(),
-            initial_class: "test".into(),
-            title: "test".into(),
-            pid: 1,
-            workspace: WmWorkspace {
-                id: workspace_id,
-                name: format!("{}", workspace_id),
-            },
-            floating: false,
-            monitor_id,
-            fullscreen,
-        }
+        // `WmClient` is #[non_exhaustive] — construct via Default + fluent setters.
+        WmClient::default()
+            .with_id(format!("0x{}", monitor_id))
+            .with_class("test")
+            .with_initial_class("test")
+            .with_title("test")
+            .with_pid(1)
+            .with_workspace(
+                WmWorkspace::default()
+                    .with_id(workspace_id)
+                    .with_name(format!("{}", workspace_id)),
+            )
+            .with_monitor_id(monitor_id)
+            .with_fullscreen(fullscreen)
     }
 
     #[test]

--- a/docs/security-template/.coderabbit.yaml
+++ b/docs/security-template/.coderabbit.yaml
@@ -42,7 +42,7 @@ reviews:
         - No command injection in hyprctl/swaymsg dispatch strings
         - Thread safety: Rc<dyn Compositor> must never cross thread boundaries
         - WmEventStream must be Send (used in background threads)
-        - Wm* types (WmClient, WmMonitor, WmWorkspace, WmEvent) are public API; once #117 lands they will be #[non_exhaustive] with builder construction — never construct via struct literal from outside nwg-common.
+        - Wm* types (WmClient, WmMonitor, WmWorkspace, WmEvent) are public API and #[non_exhaustive]. External crates must construct via `Default::default()` + the `with_*` fluent setters — never via struct literal. Same-crate (nwg-common) construction sites keep using struct literals; that's unaffected by the attribute.
     - path: "crates/nwg-common/src/launch.rs"
       instructions: |
         App launching pipeline. Verify:


### PR DESCRIPTION
## Summary
Semver-safe commitment for `nwg-common`'s foundational types before the Phase 1 crates.io publish. After this, adding a new field to any `Wm*` struct (or a new variant to `WmEvent`) is no longer a semver-major break for downstream consumers — exactly the guarantee CodeRabbit flagged during the #116 review.

## What changed
- `#[non_exhaustive]` added to **`WmClient`** (10 fields), **`WmMonitor`** (9 fields), **`WmWorkspace`** (2 fields), and **`WmEvent`** (3 variants + runway for #127's `WorkspaceChanged`).
- **21 fluent `with_*` setters** across the three structs — external crates now construct via `Default::default()` + setters:

  ```rust
  WmMonitor::default()
      .with_id(1)
      .with_name("DP-1")
      .with_width(3840)
      // ...
  ```

  Adding a new field later means adding a `with_*` method; existing call sites stay compiling.

- **Updated external construction sites** (the only external-to-`nwg-common` literal-struct sites today):
  - `crates/nwg-dock/src/ui/hotspot/cursor_poller.rs` — `test_monitor_with_workspace` and `test_client_on_workspace` rewritten to use the fluent chain.
  - All 17 same-crate construction sites in `nwg-common` left as-is — `#[non_exhaustive]` doesn't affect same-crate usage.

- **`WmEvent` match site** in `crates/nwg-dock/src/events.rs` already had a `Ok(_) => {}` fallback, so `#[non_exhaustive]` is free from a compilation standpoint. That fallback is also the runway for #127's `WorkspaceChanged` variant to land without breaking this site.

- **Refreshed `.coderabbit.yaml`** (monorepo + security-template copy) — the path_instruction that previously said "once #117 lands they will be #[non_exhaustive]" now describes the landed state.

- **`crates/nwg-common/CHANGELOG.md`** — new Changed entry documenting the construction-API migration path.

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — 367 tests pass (unchanged count)
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo doc --no-deps -p nwg-common` — zero warnings (every new `with_*` method carries rustdoc per `#![warn(missing_docs)]`)
- [ ] CI + CodeRabbit review

Closes #117. Last Phase 0 item — once merged, Phase 0 is done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fluent builder-style setters for window-manager types to simplify constructing instances.

* **Breaking Changes**
  * Several public types are now non-exhaustive; downstream code should construct via Default + fluent setters rather than struct literals (same-crate literal construction remains allowed).

* **Documentation**
  * Updated guidelines and changelog to document the new non-exhaustive status and construction pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->