### PR TITLE
Banner update: nwg-common + nwg-dock now published

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 >
 > | Tool | New repo | crates.io | Status |
 > |------|----------|-----------|--------|
-> | `nwg-common` (shared library) | [Phase 1: create repo](https://github.com/jasonherald/mac-doc-hyprland/issues/91) | [Phase 1: publish v0.3.0](https://github.com/jasonherald/mac-doc-hyprland/issues/93) | planned |
-> | `nwg-dock` (renamed from `nwg-dock-hyprland` — supports both Hyprland and Sway) | [Phase 2: create repo](https://github.com/jasonherald/mac-doc-hyprland/issues/95) | [Phase 2: publish v0.3.0](https://github.com/jasonherald/mac-doc-hyprland/issues/98) | planned |
+> | `nwg-common` (shared library) | [`jasonherald/nwg-common`](https://github.com/jasonherald/nwg-common) | [`nwg-common 0.3.0`](https://crates.io/crates/nwg-common) | ✅ published |
+> | `nwg-dock` (renamed from `nwg-dock-hyprland` — supports both Hyprland and Sway) | [`jasonherald/nwg-dock`](https://github.com/jasonherald/nwg-dock) | [`nwg-dock 0.3.0`](https://crates.io/crates/nwg-dock) | ✅ published |
 > | `nwg-drawer` | [Phase 3: create repo](https://github.com/jasonherald/mac-doc-hyprland/issues/99) | [Phase 3: publish v0.3.0](https://github.com/jasonherald/mac-doc-hyprland/issues/102) | planned |
 > | `nwg-notifications` | [Phase 4: create repo](https://github.com/jasonherald/mac-doc-hyprland/issues/103) | [Phase 4: publish v0.3.0](https://github.com/jasonherald/mac-doc-hyprland/issues/106) | planned |
 >


### PR DESCRIPTION
## Summary
Both Phase 1 + Phase 2 extractions landed:

- [`nwg-common 0.3.0`](https://crates.io/crates/nwg-common) → [`jasonherald/nwg-common`](https://github.com/jasonherald/nwg-common)
- [`nwg-dock 0.3.0`](https://crates.io/crates/nwg-dock) → [`jasonherald/nwg-dock`](https://github.com/jasonherald/nwg-dock)

Updates the root README migration banner: those two rows flip from the issue-placeholder links to direct repo + crates.io links, and the status badge changes from "planned" → "✅ published". Drawer (Phase 3) + notifications (Phase 4) rows unchanged — still pointing at their issue placeholders.

## Test plan
- [x] Both crates visible on crates.io at 0.3.0
- [x] Both GitHub repos are public and linkable
- [ ] CI + CodeRabbit review (README-only change)

Closes the banner commitment from #91 / #98.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project tracking table to reflect the published status of `nwg-common` and `nwg-dock` crates, now marked with "✅ published" status and version 0.3.0.
  * Replaced issue references with direct links to GitHub repositories and crates.io package pages for improved navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->