### PR TITLE
Banner update: nwg-drawer now published

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 > |------|----------|-----------|--------|
 > | `nwg-common` (shared library) | [`jasonherald/nwg-common`](https://github.com/jasonherald/nwg-common) | [`nwg-common 0.3.0`](https://crates.io/crates/nwg-common) | ✅ published |
 > | `nwg-dock` (renamed from `nwg-dock-hyprland` — supports both Hyprland and Sway) | [`jasonherald/nwg-dock`](https://github.com/jasonherald/nwg-dock) | [`nwg-dock 0.3.0`](https://crates.io/crates/nwg-dock) | ✅ published |
-> | `nwg-drawer` | [Phase 3: create repo](https://github.com/jasonherald/mac-doc-hyprland/issues/99) | [Phase 3: publish v0.3.0](https://github.com/jasonherald/mac-doc-hyprland/issues/102) | planned |
+> | `nwg-drawer` | [`jasonherald/nwg-drawer`](https://github.com/jasonherald/nwg-drawer) | [`nwg-drawer 0.3.0`](https://crates.io/crates/nwg-drawer) | ✅ published |
 > | `nwg-notifications` | [Phase 4: create repo](https://github.com/jasonherald/mac-doc-hyprland/issues/103) | [Phase 4: publish v0.3.0](https://github.com/jasonherald/mac-doc-hyprland/issues/106) | planned |
 >
 > **Heading to the dock?** Nothing's renamed yet — current `exec-once = nwg-dock-hyprland …` autostart lines keep working today because the binary is still called `nwg-dock-hyprland` in this monorepo. When the Phase 2 rename to `nwg-dock` lands, the Makefile will install a `nwg-dock-hyprland` → `nwg-dock` symlink ([tracked in #96](https://github.com/jasonherald/mac-doc-hyprland/issues/96)) so those autostart lines continue to work on upgrade without any config edits.


### PR DESCRIPTION
## Summary
[`nwg-drawer 0.3.0`](https://crates.io/crates/nwg-drawer) → [`jasonherald/nwg-drawer`](https://github.com/jasonherald/nwg-drawer). Phase 3 extraction complete.

Swaps the drawer row from its issue placeholders to direct repo + crates.io links; status flips to ✅ published. Notifications (Phase 4) row unchanged.

Closes Phase 3 per #99 / #102.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to reflect the published status of nwg-drawer 0.3.0 with direct links to the repository and package registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->