### PR TITLE
Flip nwg-notifications banner to published (Phase 4 complete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 > | `nwg-common` (shared library) | [`jasonherald/nwg-common`](https://github.com/jasonherald/nwg-common) | [`nwg-common 0.3.0`](https://crates.io/crates/nwg-common) | ✅ published |
 > | `nwg-dock` (renamed from `nwg-dock-hyprland` — supports both Hyprland and Sway) | [`jasonherald/nwg-dock`](https://github.com/jasonherald/nwg-dock) | [`nwg-dock 0.3.0`](https://crates.io/crates/nwg-dock) | ✅ published |
 > | `nwg-drawer` | [`jasonherald/nwg-drawer`](https://github.com/jasonherald/nwg-drawer) | [`nwg-drawer 0.3.0`](https://crates.io/crates/nwg-drawer) | ✅ published |
-> | `nwg-notifications` | [Phase 4: create repo](https://github.com/jasonherald/mac-doc-hyprland/issues/103) | [Phase 4: publish v0.3.0](https://github.com/jasonherald/mac-doc-hyprland/issues/106) | planned |
+> | `nwg-notifications` | [`jasonherald/nwg-notifications`](https://github.com/jasonherald/nwg-notifications) | [`nwg-notifications 0.3.0`](https://crates.io/crates/nwg-notifications) | ✅ published |
 >
 > **Heading to the dock?** Nothing's renamed yet — current `exec-once = nwg-dock-hyprland …` autostart lines keep working today because the binary is still called `nwg-dock-hyprland` in this monorepo. When the Phase 2 rename to `nwg-dock` lands, the Makefile will install a `nwg-dock-hyprland` → `nwg-dock` symlink ([tracked in #96](https://github.com/jasonherald/mac-doc-hyprland/issues/96)) so those autostart lines continue to work on upgrade without any config edits.
 


### PR DESCRIPTION
## Summary
- Updates the migration banner row for \`nwg-notifications\` from *planned* → ✅ published
- Links to the new standalone repo and the crates.io page
- All four ecosystem crates (\`nwg-common\`, \`nwg-dock\`, \`nwg-drawer\`, \`nwg-notifications\`) now live at 0.3.0 on crates.io

## Phase 4 recap
Closed this session:
- #103 — seeded standalone repo with daemon + D-Bus service file + tests + full infrastructure
- #104 — Makefile with \`install-dbus\` (user-scope even under sudo), committed \`.service.in\` template with \`@BIN_PATH@\` placeholder, daemon-aware \`upgrade\` target with user-scoped \`pgrep -u \$TARGET_USER -f\` process discovery (comm is truncated to 15 chars on Linux, so \`-x\` would miss the 17-char daemon name)
- #105 — security posture: 6 CI workflows + SECURITY.md + deny.toml + CodeRabbit + Sonar + GitHub ruleset
- #106 — published v0.3.0 to crates.io, tagged v0.3.0

## Test plan
- [x] README renders locally — banner row reads \"✅ published\"
- [x] Links resolve: https://github.com/jasonherald/nwg-notifications + https://crates.io/crates/nwg-notifications/0.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the per-tool repository table to reflect that `nwg-notifications` is now published on crates.io (version 0.3.0) with its official repository link, replacing the previous planned status entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->