### PR TITLE
Relock nwg-common to 0.3.0 registry source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,7 +835,9 @@ dependencies = [
 
 [[package]]
 name = "nwg-common"
-version = "0.2.0"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111ad59638979205950c1536d42540a9140793d5dacdea521e9621e2b43bb73c"
 dependencies = [
  "clap",
  "dirs",


### PR DESCRIPTION
## Summary

Regenerates \`Cargo.lock\` so it actually matches \`Cargo.toml\`.

Since PR #131 (Consume \`nwg-common\` 0.3.0 from crates.io; drop workspace member), the manifest has declared \`nwg-common = \"0.3\"\` in \`workspace.dependencies\`, but \`Cargo.lock\` was never regenerated — it still held a stale \`nwg-common = \"0.2.0\"\` entry pointing at the removed workspace path.

CI stayed green because the workflows don't pass \`--locked\`, and regular \`cargo build\` silently re-resolves against the manifest on each invocation. But a locked build fails on main today:

\`\`\`
\$ cargo build --locked
error: cannot update the lock file /…/Cargo.lock because --locked was passed to prevent this
\`\`\`

Fixed via \`cargo fetch\`, which dropped the orphaned 0.2.0 workspace entry and added the 0.3.0 registry entry with a valid checksum. Verified \`cargo build --locked\` passes after the change.

No code or manifest change — lockfile relock only.

## Why it matters (even with archive in Phase 7)

- Fixes reproducible builds for any contributor running locked builds between now and #111 (monorepo archive)
- Removes a latent source of surprise — today nothing would catch if a malicious/incorrect \`nwg-common\` version were ever published, since \`cargo build\` silently re-resolves
- Keeps the repo in a clean state going into Phase 5 dogfooding (#136)

## Test plan
- [x] \`cargo build --locked\` passes on the branch
- [x] Diff is exactly 3 lines (one orphaned entry replaced with registry source + checksum)
- [ ] CI green
- [ ] CodeRabbit review clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)